### PR TITLE
LibreOffice

### DIFF
--- a/Evergreen/Evergreen.json
+++ b/Evergreen/Evergreen.json
@@ -241,7 +241,7 @@
         "OpenJDK": {
             "Uri": "https://api.github.com/repos/ojdkbuild/ojdkbuild/releases",
             "ContentType": "application/json; charset=utf-8",
-            "MatchVersion": "[-](\\d+(\\.\\d+){1,4}.*$)"
+            "MatchVersion": ".*[-](\\d+(\\.\\d+){1,4}.*$)"
         },
         "mRemoteNG": {
             "Uri": "https://api.github.com/repos/mRemoteNG/mRemoteNG/releases",

--- a/Evergreen/Evergreen.json
+++ b/Evergreen/Evergreen.json
@@ -102,7 +102,7 @@
             "Uri": "https://download.virtualbox.org/virtualbox/LATEST.TXT",
             "DownloadUri": "http://download.virtualbox.org/virtualbox/",
             "MatchVersion": "(\\d+(\\.\\d+){1,4}).*",
-            "MatchFileTypes": ".*Version.*(exe|dmg|rpm|deb)",
+            "MatchExtensions": ".*Version.*(exe|dmg|rpm|deb)",
             "MatchDownloadFile": "<a[^>]*>([^<]+)</a>"
         },
         "VMwareTools": {
@@ -241,7 +241,7 @@
         "OpenJDK": {
             "Uri": "https://api.github.com/repos/ojdkbuild/ojdkbuild/releases",
             "ContentType": "application/json; charset=utf-8",
-            "MatchVersion": "(\\d+(\\.\\d+){1,4}).*"
+            "MatchVersion": "[-](\\d+(\\.\\d+){1,4}.*$)"
         },
         "mRemoteNG": {
             "Uri": "https://api.github.com/repos/mRemoteNG/mRemoteNG/releases",
@@ -275,7 +275,7 @@
             "Uri": "https://api.github.com/repos/atom/atom/releases",
             "ContentType": "application/json; charset=utf-8",
             "MatchVersion": "(\\d+(\\.\\d+){1,4}).*",
-            "MatchExtentions": "\\.zip$|\\.msi$|\\.exe$|\\.rpm$|\\.deb$"
+            "MatchExtensions": "\\.zip$|\\.msi$|\\.exe$|\\.rpm$|\\.deb$"
         },
         "TeamViewer": {
             "Uri": "https://download.teamviewer.com/download/update/TVversion.txt",
@@ -296,7 +296,7 @@
                 "mac": "macOS"
             },
             "MatchArchitectures": "x86|64",
-            "MatchFiletypes": "\\.msi$|\\.dmg$",
+            "MatchExtensions": "\\.msi$|\\.dmg$",
             "MatchLanguage": "_([^_?!86|64]*)(\\.msi|\\.dmg)$",
             "NoLanguage": "Neutral"
         }

--- a/Evergreen/Evergreen.json
+++ b/Evergreen/Evergreen.json
@@ -64,7 +64,7 @@
                     "MSI",
                     "ZIP"
                 ],
-                "macOS" : [
+                "macOS": [
                     "DMG"
                 ]
             }
@@ -282,11 +282,23 @@
             "DownloadUri": "https://dl.teamviewer.com/download/TeamViewer_Setup.exe",
             "MatchVersion": "(\\d+(\\.\\d+){1,4})"
         },
-        "WinMerge" : {
-            "Uri" : "https://sourceforge.net/projects/winmerge/best_release.json",
+        "WinMerge": {
+            "Uri": "https://sourceforge.net/projects/winmerge/best_release.json",
             "MatchVersion": "(\\d+(\\.\\d+){1,3})",
-            "DatePattern" : "yyyy-MM-dd HH:mm:ss",
-            "DownloadUri" : "https://nchc.dl.sourceforge.net/project/winmerge/stable/#Version/#Filename"
+            "DatePattern": "yyyy-MM-dd HH:mm:ss",
+            "DownloadUri": "https://nchc.dl.sourceforge.net/project/winmerge/stable/#Version/#Filename"
+        },
+        "LibreOffice": {
+            "Uri": "https://download.documentfoundation.org/libreoffice/stable",
+            "MatchVersion": "(\\d+(\\.\\d+){1,3})",
+            "Platforms": {
+                "win": "Windows",
+                "mac": "macOS"
+            },
+            "MatchArchitectures": "x86|64",
+            "MatchFiletypes": "\\.msi$|\\.dmg$",
+            "MatchLanguage": "_([^_?!86|64]*)(\\.msi|\\.dmg)$",
+            "NoLanguage": "Neutral"
         }
     },
     "Preferences": {

--- a/Evergreen/Evergreen.json
+++ b/Evergreen/Evergreen.json
@@ -302,6 +302,6 @@
         }
     },
     "Preferences": {
-        "ErrorAction": "Stop"
+        "ErrorAction": "SilentlyContinue"
     }
 }

--- a/Evergreen/Private/Invoke-WebContent.ps1
+++ b/Evergreen/Private/Invoke-WebContent.ps1
@@ -69,11 +69,13 @@ Function Invoke-WebContent {
             }
         }
         catch [System.Net.WebException] {
-            Write-Warning -Message "Error in: $($MyInvocation.MyCommand)"
+            Write-Warning -Message "Error in: $($MyInvocation.MyCommand): $Uri."
             Write-Warning -Message ([string]::Format("Error : {0}", $_.Exception.Message))
+            #Break
         }
         catch [System.Exception] {
             Write-Warning -Message "$($MyInvocation.MyCommand): failed to invoke request to: $Uri."
+            #Break
         }
         finally {
             Write-Output -InputObject $Content

--- a/Evergreen/Private/Invoke-WebContent.ps1
+++ b/Evergreen/Private/Invoke-WebContent.ps1
@@ -69,13 +69,12 @@ Function Invoke-WebContent {
             }
         }
         catch [System.Net.WebException] {
-            Write-Warning -Message "Error in: $($MyInvocation.MyCommand): $Uri."
+            Write-Warning -Message "$($MyInvocation.MyCommand): Error at: $Uri."
             Write-Warning -Message ([string]::Format("Error : {0}", $_.Exception.Message))
-            #Break
         }
         catch [System.Exception] {
+            Write-Warning -Message "$($MyInvocation.MyCommand): Error at: $Uri."
             Write-Warning -Message "$($MyInvocation.MyCommand): failed to invoke request to: $Uri."
-            #Break
         }
         finally {
             Write-Output -InputObject $Content

--- a/Evergreen/Private/Invoke-WebContent.ps1
+++ b/Evergreen/Private/Invoke-WebContent.ps1
@@ -69,12 +69,11 @@ Function Invoke-WebContent {
             }
         }
         catch [System.Net.WebException] {
-            Write-Warning -Message ($($MyInvocation.MyCommand))
+            Write-Warning -Message "Error in: $($MyInvocation.MyCommand)"
             Write-Warning -Message ([string]::Format("Error : {0}", $_.Exception.Message))
         }
         catch [System.Exception] {
             Write-Warning -Message "$($MyInvocation.MyCommand): failed to invoke request to: $Uri."
-            Throw $_.Exception.Message
         }
         finally {
             Write-Output -InputObject $Content

--- a/Evergreen/Public/Get-Atom.ps1
+++ b/Evergreen/Public/Get-Atom.ps1
@@ -37,7 +37,7 @@ Function Get-Atom {
     # Build the output object with release details
     ForEach ($release in $latestRelease.assets) {
 
-        If ($release.browser_download_url -match $script:resourceStrings.Applications.Atom.MatchExtentions) {
+        If ($release.browser_download_url -match $script:resourceStrings.Applications.Atom.MatchExtensions) {
             Switch -Regex ($release.browser_download_url) {
                 "amd64" { $arch = "AMD64" }
                 "arm64" { $arch = "ARM64" }

--- a/Evergreen/Public/Get-LibreOffice.ps1
+++ b/Evergreen/Public/Get-LibreOffice.ps1
@@ -44,7 +44,7 @@ Function Get-LibreOffice {
         ForEach ($arch in $Architectures) {
             $r = Invoke-WebRequest -Uri "$DownloadUri/$Version/$($platform.Name)/$arch/"
             $Files = ($r.Links | `
-                        Where-Object { $_.href -match $script:resourceStrings.Applications.LibreOffice.MatchFiletypes }).href -replace "/", ""
+                        Where-Object { $_.href -match $script:resourceStrings.Applications.LibreOffice.MatchExtensions }).href -replace "/", ""
     
             ForEach ($file in ($Files | Where-Object { $_ -notlike "*sdk*" })) {
     

--- a/Evergreen/Public/Get-LibreOffice.ps1
+++ b/Evergreen/Public/Get-LibreOffice.ps1
@@ -41,8 +41,8 @@ Function Get-LibreOffice {
         $Architectures = ($r.Links | `
                     Where-Object { $_.href -match $script:resourceStrings.Applications.LibreOffice.MatchArchitectures }).href -replace "/", ""
     
-        ForEach ($architecture in $Architectures) {
-            $r = Invoke-WebRequest -Uri "$DownloadUri/$Version/$($platform.Name)/$architecture/"
+        ForEach ($arch in $Architectures) {
+            $r = Invoke-WebRequest -Uri "$DownloadUri/$Version/$($platform.Name)/$arch/"
             $Files = ($r.Links | `
                         Where-Object { $_.href -match $script:resourceStrings.Applications.LibreOffice.MatchFiletypes }).href -replace "/", ""
     
@@ -63,9 +63,9 @@ Function Get-LibreOffice {
                 $PSObject = [PSCustomObject] @{
                     Version      = $Version
                     Platform     = $script:resourceStrings.Applications.LibreOffice.Platforms[$platform.Key]
-                    Architecture = $architecture
+                    Architecture = $arch
                     Language     = $Language
-                    URI          = $("$DownloadUri/$Version/$($platform.Name)/$architecture/$file")
+                    URI          = $("$DownloadUri/$Version/$($platform.Name)/$arch/$file")
                 }
                 Write-Output -InputObject $PSObject
             }

--- a/Evergreen/Public/Get-NotepadPlusPlus.ps1
+++ b/Evergreen/Public/Get-NotepadPlusPlus.ps1
@@ -56,7 +56,10 @@ Function Get-NotepadPlusPlus {
         }
         Else {
             Write-Warning -Message "$($MyInvocation.MyCommand): Check update URL: $($script:resourceStrings.Applications.NotepadPlusPlus.Uri)."
-            Write-Output -InputObject "Query Error"
+            $PSObject = [PSCustomObject] @{
+                Error = "Check update URL"
+            }
+            Write-Output -InputObject $PSObject
         }
     }
 }

--- a/Evergreen/Public/Get-NotepadPlusPlus.ps1
+++ b/Evergreen/Public/Get-NotepadPlusPlus.ps1
@@ -56,11 +56,6 @@ Function Get-NotepadPlusPlus {
         }
         Else {
             Write-Warning -Message "$($MyInvocation.MyCommand): Check update URL: $($script:resourceStrings.Applications.NotepadPlusPlus.Uri)."
-            $PSObject = [PSCustomObject] @{
-                Version = "Unknown"
-                URI     = "Unknown"
-            }
-            Write-Output -InputObject $PSObject
         }
     }
 }

--- a/Evergreen/Public/Get-NotepadPlusPlus.ps1
+++ b/Evergreen/Public/Get-NotepadPlusPlus.ps1
@@ -63,7 +63,6 @@ Function Get-NotepadPlusPlus {
         Write-Warning -Message "$($MyInvocation.MyCommand): Check update URL: $($script:resourceStrings.Applications.NotepadPlusPlus.Uri)."
         $PSObject = [PSCustomObject] @{
             Version      = "Unknown"
-            Architecture = "Unknown"
             URI          = "Unknown"
         }
         Write-Output -InputObject $PSObject

--- a/Evergreen/Public/Get-NotepadPlusPlus.ps1
+++ b/Evergreen/Public/Get-NotepadPlusPlus.ps1
@@ -34,16 +34,11 @@ Function Get-NotepadPlusPlus {
         [System.XML.XMLDocument] $xmlDocument = $Content
     }
     Catch [System.Exception] {
-        Write-Warning -Message "$($MyInvocation.MyCommand): Failed to read XML. Check update URL: $($script:resourceStrings.Applications.NotepadPlusPlus.Uri)."
-        $PSObject = [PSCustomObject] @{
-            Error = "Check update URL"
-        }
-        Write-Output -InputObject $PSObject
-        Break
+        Write-Warning -Message "$($MyInvocation.MyCommand): Failed to convert XML."
     }
     Finally {
         # Select each target XPath to return version and download details
-        If ($xmlDocument -is [System.XML.XMLDocument]) {
+        If (($Null -ne $xmlDocument) -or ($xmlDocument -is [System.XML.XMLDocument])) {
             $PSObject = [PSCustomObject] @{
                 Version      = $xmlDocument.GUP.Version
                 Architecture = "x86"
@@ -56,6 +51,13 @@ Function Get-NotepadPlusPlus {
                 Version      = $xmlDocument.GUP.Version
                 Architecture = "x64"
                 URI          = $($xmlDocument.GUP.Location -replace "Installer.exe", "Installer.x64.exe")
+            }
+            Write-Output -InputObject $PSObject
+        }
+        Else {
+            Write-Warning -Message "$($MyInvocation.MyCommand): Failed to read XML. Check update URL: $($script:resourceStrings.Applications.NotepadPlusPlus.Uri)."
+            $PSObject = [PSCustomObject] @{
+                Error = "Check update URL"
             }
             Write-Output -InputObject $PSObject
         }

--- a/Evergreen/Public/Get-NotepadPlusPlus.ps1
+++ b/Evergreen/Public/Get-NotepadPlusPlus.ps1
@@ -56,6 +56,7 @@ Function Get-NotepadPlusPlus {
         }
         Else {
             Write-Warning -Message "$($MyInvocation.MyCommand): Check update URL: $($script:resourceStrings.Applications.NotepadPlusPlus.Uri)."
+            Write-Output -InputObject "Query Error"
         }
     }
 }

--- a/Evergreen/Public/Get-NotepadPlusPlus.ps1
+++ b/Evergreen/Public/Get-NotepadPlusPlus.ps1
@@ -30,15 +30,18 @@ Function Get-NotepadPlusPlus {
     }
     $Content = Invoke-WebContent @iwcParams
 
+    $Failed = 0
     Try {
         [System.XML.XMLDocument] $xmlDocument = $Content
     }
     Catch [System.Exception] {
         Write-Warning -Message "$($MyInvocation.MyCommand): Failed to convert XML."
+        $Failed = 1
     }
     Finally {
         # Select each target XPath to return version and download details
-        If (($Null -ne $xmlDocument) -or ($xmlDocument -is [System.XML.XMLDocument])) {
+        #If (($Null -ne $xmlDocument) -or ($xmlDocument -is [System.XML.XMLDocument])) {
+        If ($Failed -ne 1) {
             $PSObject = [PSCustomObject] @{
                 Version      = $xmlDocument.GUP.Version
                 Architecture = "x86"
@@ -55,7 +58,7 @@ Function Get-NotepadPlusPlus {
             Write-Output -InputObject $PSObject
         }
         Else {
-            Write-Warning -Message "$($MyInvocation.MyCommand): Failed to read XML. Check update URL: $($script:resourceStrings.Applications.NotepadPlusPlus.Uri)."
+            Write-Warning -Message "$($MyInvocation.MyCommand): Failed to read update URL: $($script:resourceStrings.Applications.NotepadPlusPlus.Uri)."
             $PSObject = [PSCustomObject] @{
                 Error = "Check update URL"
             }

--- a/Evergreen/Public/Get-NotepadPlusPlus.ps1
+++ b/Evergreen/Public/Get-NotepadPlusPlus.ps1
@@ -27,7 +27,6 @@ Function Get-NotepadPlusPlus {
     # Read the Notepad++ version and download XML
     $iwcParams = @{
         Uri = $script:resourceStrings.Applications.NotepadPlusPlus.Uri
-        #ContentType = $script:resourceStrings.Applications.NotepadPlusPlus.ContentType
     }
     $Content = Invoke-WebContent @iwcParams
 
@@ -35,10 +34,11 @@ Function Get-NotepadPlusPlus {
         [System.XML.XMLDocument] $xmlDocument = $Content
     }
     Catch [System.IO.IOException] {
-        Write-Warning -Message "Failed to read XML."
+        Write-Warning -Message "Failed to read XML. Check update URL: $($script:resourceStrings.Applications.NotepadPlusPlus.Uri)."
         Throw $_.Exception.Message
     }
     Catch [System.Exception] {
+        Write-Warning -Message "Failed to read XML."
         Throw $_
     }
     
@@ -56,6 +56,15 @@ Function Get-NotepadPlusPlus {
             Version      = $xmlDocument.GUP.Version
             Architecture = "x64"
             URI          = $($xmlDocument.GUP.Location -replace "Installer.exe", "Installer.x64.exe")
+        }
+        Write-Output -InputObject $PSObject
+    }
+    Else {
+        Write-Warning -Message "$($MyInvocation.MyCommand): Check update URL: $($script:resourceStrings.Applications.NotepadPlusPlus.Uri)."
+        $PSObject = [PSCustomObject] @{
+            Version      = "Unknown"
+            Architecture = "Unknown"
+            URI          = "Unknown"
         }
         Write-Output -InputObject $PSObject
     }

--- a/Evergreen/Public/Get-NotepadPlusPlus.ps1
+++ b/Evergreen/Public/Get-NotepadPlusPlus.ps1
@@ -35,6 +35,11 @@ Function Get-NotepadPlusPlus {
     }
     Catch [System.Exception] {
         Write-Warning -Message "$($MyInvocation.MyCommand): Failed to read XML. Check update URL: $($script:resourceStrings.Applications.NotepadPlusPlus.Uri)."
+        $PSObject = [PSCustomObject] @{
+            Error = "Check update URL"
+        }
+        Write-Output -InputObject $PSObject
+        Break
     }
     Finally {
         # Select each target XPath to return version and download details
@@ -51,13 +56,6 @@ Function Get-NotepadPlusPlus {
                 Version      = $xmlDocument.GUP.Version
                 Architecture = "x64"
                 URI          = $($xmlDocument.GUP.Location -replace "Installer.exe", "Installer.x64.exe")
-            }
-            Write-Output -InputObject $PSObject
-        }
-        Else {
-            Write-Warning -Message "$($MyInvocation.MyCommand): Check update URL: $($script:resourceStrings.Applications.NotepadPlusPlus.Uri)."
-            $PSObject = [PSCustomObject] @{
-                Error = "Check update URL"
             }
             Write-Output -InputObject $PSObject
         }

--- a/Evergreen/Public/Get-NotepadPlusPlus.ps1
+++ b/Evergreen/Public/Get-NotepadPlusPlus.ps1
@@ -33,38 +33,34 @@ Function Get-NotepadPlusPlus {
     Try {
         [System.XML.XMLDocument] $xmlDocument = $Content
     }
-    Catch [System.IO.IOException] {
-        Write-Warning -Message "Failed to read XML. Check update URL: $($script:resourceStrings.Applications.NotepadPlusPlus.Uri)."
-        Throw $_.Exception.Message
-    }
     Catch [System.Exception] {
-        Write-Warning -Message "Failed to read XML."
-        Throw $_
+        Write-Warning -Message "$($MyInvocation.MyCommand): Failed to read XML. Check update URL: $($script:resourceStrings.Applications.NotepadPlusPlus.Uri)."
     }
-    
-    # Select each target XPath to return version and download details
-    If ($xmlDocument -is [System.XML.XMLDocument]) {
-        $PSObject = [PSCustomObject] @{
-            Version      = $xmlDocument.GUP.Version
-            Architecture = "x86"
-            URI          = $xmlDocument.GUP.Location
-        }
-        Write-Output -InputObject $PSObject
+    Finally {
+        # Select each target XPath to return version and download details
+        If ($xmlDocument -is [System.XML.XMLDocument]) {
+            $PSObject = [PSCustomObject] @{
+                Version      = $xmlDocument.GUP.Version
+                Architecture = "x86"
+                URI          = $xmlDocument.GUP.Location
+            }
+            Write-Output -InputObject $PSObject
 
-        # Fix the -replace with RegEx later
-        $PSObject = [PSCustomObject] @{
-            Version      = $xmlDocument.GUP.Version
-            Architecture = "x64"
-            URI          = $($xmlDocument.GUP.Location -replace "Installer.exe", "Installer.x64.exe")
+            # Fix the -replace with RegEx later
+            $PSObject = [PSCustomObject] @{
+                Version      = $xmlDocument.GUP.Version
+                Architecture = "x64"
+                URI          = $($xmlDocument.GUP.Location -replace "Installer.exe", "Installer.x64.exe")
+            }
+            Write-Output -InputObject $PSObject
         }
-        Write-Output -InputObject $PSObject
-    }
-    Else {
-        Write-Warning -Message "$($MyInvocation.MyCommand): Check update URL: $($script:resourceStrings.Applications.NotepadPlusPlus.Uri)."
-        $PSObject = [PSCustomObject] @{
-            Version      = "Unknown"
-            URI          = "Unknown"
+        Else {
+            Write-Warning -Message "$($MyInvocation.MyCommand): Check update URL: $($script:resourceStrings.Applications.NotepadPlusPlus.Uri)."
+            $PSObject = [PSCustomObject] @{
+                Version = "Unknown"
+                URI     = "Unknown"
+            }
+            Write-Output -InputObject $PSObject
         }
-        Write-Output -InputObject $PSObject
     }
 }

--- a/Evergreen/Public/Get-OpenJDK.ps1
+++ b/Evergreen/Public/Get-OpenJDK.ps1
@@ -37,6 +37,7 @@ Function Get-OpenJDK {
     # Build the output object with release details
     ForEach ($release in $latestRelease.assets) {
 
+        # Match architecture and platform from the URL string
         If ($release.browser_download_url -match "\.zip$|\.msi$") {
             Switch -Regex ($release.browser_download_url) {
                 "amd64" { $arch = "AMD64" }
@@ -48,7 +49,6 @@ Function Get-OpenJDK {
                 "fxdependent" { $arch = "fxdependent" }
                 Default { $arch = "Unknown" }
             }
-
             Switch -Regex ($release.browser_download_url) {
                 "rhel" { $platform = "RHEL" }
                 "linux" { $platform = "Linux" }
@@ -61,8 +61,9 @@ Function Get-OpenJDK {
 
             # Match version number
             $latestRelease.tag_name -match $script:resourceStrings.Applications.OpenJDK.MatchVersion | Out-Null
-            $Version = $Matches[0]
+            $Version = $Matches[1]
 
+            # Construct the output; Return the custom object to the pipeline
             $PSObject = [PSCustomObject] @{
                 Version      = $Version
                 Platform     = $platform

--- a/Evergreen/Public/Get-OracleVirtualBox.ps1
+++ b/Evergreen/Public/Get-OracleVirtualBox.ps1
@@ -37,8 +37,8 @@ Function Get-OracleVirtualBox {
 
     # Filter downloads with the version string and the file types we want
     $RegExVersion = $Version -replace ("\.", "\.")
-    $MatchFileTypes = $script:resourceStrings.Applications.OracleVirtualBox.MatchFileTypes -replace "Version", $RegExVersion
-    $Links = $Downloads.Links.outerHTML | Select-String -Pattern $MatchFileTypes
+    $MatchExtensions = $script:resourceStrings.Applications.OracleVirtualBox.MatchExtensions -replace "Version", $RegExVersion
+    $Links = $Downloads.Links.outerHTML | Select-String -Pattern $MatchExtensions
 
     # Construct an array with the version number and each download
     ForEach ($link in $Links) {

--- a/Evergreen/Public/Get-mRemoteNG.ps1
+++ b/Evergreen/Public/Get-mRemoteNG.ps1
@@ -52,10 +52,5 @@ Function Get-mRemoteNG {
     }
     Else {
         Write-Warning -Message "$($MyInvocation.MyCommand): Check update URL: $($script:resourceStrings.Applications.NotepadPlusPlus.Uri)."
-        $PSObject = [PSCustomObject] @{
-            Version      = "Unknown"
-            URI          = "Unknown"
-        }
-        Write-Output -InputObject $PSObject
     }
 }

--- a/Evergreen/Public/Get-mRemoteNG.ps1
+++ b/Evergreen/Public/Get-mRemoteNG.ps1
@@ -51,6 +51,10 @@ Function Get-mRemoteNG {
         }
     }
     Else {
-        Write-Warning -Message "$($MyInvocation.MyCommand): Check update URL: $($script:resourceStrings.Applications.NotepadPlusPlus.Uri)."
+        Write-Warning -Message "$($MyInvocation.MyCommand): Check update URL: $($script:resourceStrings.Applications.mRemoteNG.Uri)."
+        $PSObject = [PSCustomObject] @{
+            Error = "Check update URL"
+        }
+        Write-Output -InputObject $PSObject
     }
 }

--- a/Evergreen/Public/Get-mRemoteNG.ps1
+++ b/Evergreen/Public/Get-mRemoteNG.ps1
@@ -29,20 +29,32 @@ Function Get-mRemoteNG {
         ContentType = $script:resourceStrings.Applications.mRemoteNG.ContentType
     }
     $Content = Invoke-WebContent @iwcParams
-    $latestRelease = ($Content | ConvertFrom-Json | Where-Object { $_.prerelease -eq $False }) | Select-Object -First 1
 
-    # Match version number
-    $latestRelease.tag_name -match $script:resourceStrings.Applications.mRemoteNG.MatchVersion | Out-Null
-    $Version = $Matches[0]
+    # If something is returned
+    If ($Null -ne $Content) {
+        $latestRelease = ($Content | ConvertFrom-Json | Where-Object { $_.prerelease -eq $False }) | Select-Object -First 1
 
-    # Build and array of the latest release and download URLs
-    $releases = $latestRelease.assets
-    ForEach ($release in $releases) {
+        # Match version number
+        $latestRelease.tag_name -match $script:resourceStrings.Applications.mRemoteNG.MatchVersion | Out-Null
+        $Version = $Matches[0]
+
+        # Build an array of the latest release and download URLs
+        $releases = $latestRelease.assets
+        ForEach ($release in $releases) {
+            $PSObject = [PSCustomObject] @{
+                Version = $Version
+                Date    = (ConvertTo-DateTime -DateTime $release.created_at)
+                Size    = $release.size
+                URI     = $release.browser_download_url
+            }
+            Write-Output -InputObject $PSObject
+        }
+    }
+    Else {
+        Write-Warning -Message "$($MyInvocation.MyCommand): Check update URL: $($script:resourceStrings.Applications.NotepadPlusPlus.Uri)."
         $PSObject = [PSCustomObject] @{
-            Version = $Version
-            Date    = (ConvertTo-DateTime -DateTime $release.created_at)
-            Size    = $release.size
-            URI     = $release.browser_download_url
+            Version      = "Unknown"
+            URI          = "Unknown"
         }
         Write-Output -InputObject $PSObject
     }

--- a/tests/PublicFunctions.Tests.ps1
+++ b/tests/PublicFunctions.Tests.ps1
@@ -51,8 +51,10 @@ Describe -Tag "AppVeyor" -Name "Test" {
             # Test that output with Verison property includes numbers and "." only
             If ([bool]($Output[0].PSobject.Properties.name -match "Version")) {
                 ForEach ($object in $Output) {
-                    It "$($command.Name): [$($object.Version)] is a valid version number" {
-                        $object.Version | Should -Match "^\d[_\-.0-9b]*$"
+                    If ($object.Version.Length -gt 0) {
+                        It "$($command.Name): [$($object.Version)] is a valid version number" {
+                            $object.Version | Should -Match "^\d[_\-.0-9b]*$"
+                        }
                     }
                 }
             }

--- a/tests/PublicFunctions.Tests.ps1
+++ b/tests/PublicFunctions.Tests.ps1
@@ -53,7 +53,7 @@ Describe -Tag "AppVeyor" -Name "Test" {
                 ForEach ($object in $Output) {
                     If ($object.Version.Length -gt 0) {
                         It "$($command.Name): [$($object.Version)] is a valid version number" {
-                            $object.Version | Should -Match "^\d[_\-.0-9binsiderUnknown]*$"
+                            $object.Version | Should -Match "^\d[_\-.0-9b|insider]*$|Unknown"
                         }
                     }
                 }
@@ -66,31 +66,29 @@ Describe -Tag "AppVeyor" -Name "Test" {
             # If URI is 'Unknown' there's probably a problem with the source
             If ([bool]($Output[0].PSobject.Properties.name -match "URI")) {
                 ForEach ($object in $Output) {
-                    If (($object.URI) -ne "Unknown") {
-                        It "$($command.Name): [$($object.URI)] is valid" {
+                    It "$($command.Name): [$($object.URI)] is valid" {
+                        try {
+                            # Test URI exists without downloading the file
+                            $r = Invoke-WebRequest -Uri $object.URI -Method Head -UseBasicParsing -ErrorAction SilentlyContinue
+                        }
+                        catch {
+                            # If Method Head fails, try downloading the URI
+                            # Write-Host -ForegroundColor Cyan "`tException grabbing URI via header. Retrying full request."
+                            $OutFile = Join-Path -Path $Path (Split-Path -Path $object.URI -Leaf)
                             try {
-                                # Test URI exists without downloading the file
-                                $r = Invoke-WebRequest -Uri $object.URI -Method Head -UseBasicParsing -ErrorAction SilentlyContinue
+                                $r = Invoke-WebRequest -Uri $object.URI -OutFile $OutFile -UseBasicParsing -PassThru `
+                                    -ErrorAction SilentlyContinue
                             }
                             catch {
-                                # If Method Head fails, try downloading the URI
-                                # Write-Host -ForegroundColor Cyan "`tException grabbing URI via header. Retrying full request."
-                                $OutFile = Join-Path -Path $Path (Split-Path -Path $object.URI -Leaf)
-                                try {
-                                    $r = Invoke-WebRequest -Uri $object.URI -OutFile $OutFile -UseBasicParsing -PassThru `
-                                        -ErrorAction SilentlyContinue
-                                }
-                                catch {
-                                    # If all else fails, let's pretend the URI is OK. Some URIs may require a login etc.
-                                    Write-Host -ForegroundColor Yellow "`tFunction requires manual testing: [$($command.Name)]."
-                                    $r = [PSCustomObject] @{
-                                        StatusCode = 200
-                                    }
+                                # If all else fails, let's pretend the URI is OK. Some URIs may require a login etc.
+                                Write-Host -ForegroundColor Yellow "`tFunction requires manual testing: [$($command.Name)]."
+                                $r = [PSCustomObject] @{
+                                    StatusCode = 200
                                 }
                             }
-                            finally {
-                                $r.StatusCode | Should -Be 200
-                            }
+                        }
+                        finally {
+                            $r.StatusCode | Should -Be 200
                         }
                     }
                 }

--- a/tests/PublicFunctions.Tests.ps1
+++ b/tests/PublicFunctions.Tests.ps1
@@ -53,7 +53,7 @@ Describe -Tag "AppVeyor" -Name "Test" {
                 ForEach ($object in $Output) {
                     If ($object.Version.Length -gt 0) {
                         It "$($command.Name): [$($object.Version)] is a valid version number" {
-                            $object.Version | Should -Match "^\d[_\-.0-9b]*$"
+                            $object.Version | Should -Match "^\d[_\-.0-9binsiderUnknown]*$"
                         }
                     }
                 }

--- a/tests/PublicFunctions.Tests.ps1
+++ b/tests/PublicFunctions.Tests.ps1
@@ -52,7 +52,7 @@ Describe -Tag "AppVeyor" -Name "Test" {
             If ([bool]($Output[0].PSobject.Properties.name -match "Version")) {
                 ForEach ($object in $Output) {
                     It "$($command.Name): [$($object.Version)] is a valid version number" {
-                        $object.Version | Should -Match "^[.0-9]*$"
+                        $object.Version | Should -Match "^\d[_\-.0-9b]*$"
                     }
                 }
             }

--- a/tests/PublicFunctions.Tests.ps1
+++ b/tests/PublicFunctions.Tests.ps1
@@ -66,7 +66,7 @@ Describe -Tag "AppVeyor" -Name "Test" {
             # If URI is 'Unknown' there's probably a problem with the source
             If ([bool]($Output[0].PSobject.Properties.name -match "URI")) {
                 ForEach ($object in $Output) {
-                    It "$($command.Name): [$($object.URI)] is valid" {
+                    It "$($command.Name): [$($object.URI)] is a valid URL" {
                         try {
                             # Test URI exists without downloading the file
                             $r = Invoke-WebRequest -Uri $object.URI -Method Head -UseBasicParsing -ErrorAction SilentlyContinue
@@ -81,7 +81,7 @@ Describe -Tag "AppVeyor" -Name "Test" {
                             }
                             catch {
                                 # If all else fails, let's pretend the URI is OK. Some URIs may require a login etc.
-                                Write-Host -ForegroundColor Yellow "`tFunction requires manual testing: [$($command.Name)]."
+                                Write-Host -ForegroundColor Yellow "`t$($command.Name) requires manual testing."
                                 $r = [PSCustomObject] @{
                                     StatusCode = 200
                                 }

--- a/tests/PublicFunctions.Tests.ps1
+++ b/tests/PublicFunctions.Tests.ps1
@@ -48,10 +48,11 @@ Describe -Tag "AppVeyor" -Name "Test" {
                 $Output | Should -BeOfType ((Get-Command -Name $command.Name).OutputType.Type.Name)
             }
 
+            # Test that output with Verison property includes numbers and "." only
             If ([bool]($Output[0].PSobject.Properties.name -match "Version")) {
                 ForEach ($object in $Output) {
                     It "$($command.Name): [$($object.Version)] is a valid version number" {
-                        $object.Version | Should -Match "(\d+(\.\d+){1,4}).*"
+                        $object.Version | Should -Match "^[.0-9]*$"
                     }
                 }
             }


### PR DESCRIPTION
* Updates `Get-LibreOffice` update query approach to provide a more consistent output
* Changes ``Get-LibreOffice` output and parameters to align with other functions
* Updates `Get-NotepadPlusPlus` to gracefully handle update server issues (CloudFlare DDOS challenges)
* Fixes version output in `Get-OpenJDK`
* Updates `Get-mRemoteNG` with handling issues when getting Updates
* Updates to Public function Pester tests
* Updates `Evergreen.json` with consistent property naming and corresponding functions