### PR TITLE
TeamViewer / Zoom

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log
 
+## VERSION
+
+* Updates URL to current version for `TeamViewer`. New URL requires different approach to query
+* Adds `Invoke-SystemNetRequest` that uses `System.Net.WebRequest` to make a HTTP request and return response
+* Updates `Get-TeamViewer` to use `Invoke-SystemNetRequest` to retrieve version from updated URL. Updates code to return version and download URL as a result
+* Updates `Get-Zoom` to use `Resolve-Uri` to follow download URLs and find version number. `Get-Zoom` now returns more versions numbers for Zoom downloads than previously. Updates RegEx approach to return version numbers from URLs
+
 ## 2004.126
 
 * Adds back `Get-FileZilla` using the application update API. Currently returns only the 64-bit version of FileZilla for Windows.

--- a/Evergreen/Manifests/TeamViewer.json
+++ b/Evergreen/Manifests/TeamViewer.json
@@ -2,7 +2,7 @@
 	"Name": "TeamViewer",
 	"Source": "https://www.teamviewer.com/",
 	"Get": {
-		"Uri": "https://download.teamviewer.com/download/update/TVversion.txt",
+		"Uri": "https://download.teamviewer.com/download/update/TVversion15.txt",
 		"DownloadUri": "https://dl.teamviewer.com/download/TeamViewer_Setup.exe",
 		"MatchVersion": "(\\d+(\\.\\d+){1,4})"
 	},

--- a/Evergreen/Manifests/Zoom.json
+++ b/Evergreen/Manifests/Zoom.json
@@ -22,7 +22,8 @@
 		"VMwareVDIUris": {
 			"Client": "https://zoom.us/download/vdi/ZoomVmwareMediaPlugin.msi"
 		},
-		"MatchVersion": "(?<=/)\\d+(\\.\\d+){2,}(?=\\.\\d+/)"
+		"MatchVersion": "(?<=/)\\d+(\\.\\d+){2,}(?=\\.\\d+/)",
+		"MatchUrl": "(.*)\\?"
 	},
 	"Install": {
 		"Setup": "Zoom*.exe",

--- a/Evergreen/Private/Get-SystemNetRequest.ps1
+++ b/Evergreen/Private/Get-SystemNetRequest.ps1
@@ -1,0 +1,31 @@
+Function Get-SystemNetRequest {
+    <#
+        .SYNOPSIS
+            Resolved a URL that returns a 301/302 response and returns the redirected URL.
+    #>
+    [OutputType([System.String])]
+    [CmdletBinding()]
+    Param(
+        [Parameter(Mandatory = $True, Position = 0)]
+        [ValidateNotNullOrEmpty()]
+        [System.String] $Uri
+    )
+    
+    Try {
+        $httpWebRequest = [System.Net.WebRequest]::Create($Uri)
+        $httpWebRequest.MaximumAutomaticRedirections = 3
+        $httpWebRequest.AllowAutoRedirect = $true
+        $webResponse = $httpWebRequest.GetResponse()
+        $responseStream = $webResponse.GetResponseStream()
+        $streamReader = New-Object -TypeName "System.IO.StreamReader" $responseStream
+        $result = $streamReader.ReadToEnd()
+    }
+    Catch [System.Exception] {
+        Write-Verbose -Message "$($MyInvocation.MyCommand): Response: $($_.Exception.Response.StatusCode) - $($_.Exception.Response.ReasonPhrase)"
+        Throw $_
+    }
+    Finally {
+        Write-Output -InputObject $result
+        $webResponse.Dispose()
+    }
+}

--- a/Evergreen/Private/Get-SystemNetRequest.ps1
+++ b/Evergreen/Private/Get-SystemNetRequest.ps1
@@ -19,13 +19,13 @@ Function Get-SystemNetRequest {
         $responseStream = $webResponse.GetResponseStream()
         $streamReader = New-Object -TypeName "System.IO.StreamReader" $responseStream
         $result = $streamReader.ReadToEnd()
+        Write-Output -InputObject $result
     }
     Catch [System.Exception] {
-        Write-Verbose -Message "$($MyInvocation.MyCommand): Response: $($_.Exception.Response.StatusCode) - $($_.Exception.Response.ReasonPhrase)"
+        Write-Verbose -Message "$($MyInvocation.MyCommand): Response: $($webResponse.StatusCode) - $($webResponse.StatusDescription)"
         Throw $_
     }
     Finally {
-        Write-Output -InputObject $result
         $webResponse.Dispose()
     }
 }

--- a/Evergreen/Private/Invoke-SystemNetRequest.ps1
+++ b/Evergreen/Private/Invoke-SystemNetRequest.ps1
@@ -1,7 +1,7 @@
-Function Get-SystemNetRequest {
+Function Invoke-SystemNetRequest {
     <#
         .SYNOPSIS
-            Resolved a URL that returns a 301/302 response and returns the redirected URL.
+            Uses System.Net.WebRequest to make a HTTP request and returns the response.
     #>
     [OutputType([System.String])]
     [CmdletBinding()]

--- a/Evergreen/Private/Resolve-Uri.ps1
+++ b/Evergreen/Private/Resolve-Uri.ps1
@@ -19,7 +19,8 @@ Function Resolve-Uri {
         Write-Output -InputObject $webResponse.ResponseUri.AbsoluteUri
     }
     catch {
-        throw $_
+        Write-Verbose -Message "$($MyInvocation.MyCommand): Response: $($webResponse.StatusCode) - $($webResponse.StatusDescription)"
+        Throw $_
     }
     finally {
         $webResponse.Dispose()

--- a/Evergreen/Public/Get-TeamViewer.ps1
+++ b/Evergreen/Public/Get-TeamViewer.ps1
@@ -26,7 +26,7 @@ Function Get-TeamViewer {
     Write-Verbose -Message $res.Name
 
     # Get the latest TeamViewer version
-    $Content = Get-SystemNetRequest -Uri $res.Get.Uri
+    $Content = Invoke-SystemNetRequest -Uri $res.Get.Uri
 
     # Construct the output; Return the custom object to the pipeline
     If ($Null -ne $Content) {

--- a/Evergreen/Public/Get-TeamViewer.ps1
+++ b/Evergreen/Public/Get-TeamViewer.ps1
@@ -25,23 +25,13 @@ Function Get-TeamViewer {
     $res = Get-FunctionResource -AppName ("$($MyInvocation.MyCommand)".Split("-"))[1]
     Write-Verbose -Message $res.Name
 
-    #region Get current version for Windows
-    $Content = Invoke-WebContent -Uri $res.Get.Uri -Raw
+    # Get the latest TeamViewer version
+    $Content = Get-SystemNetRequest -Uri $res.Get.Uri
 
+    # Construct the output; Return the custom object to the pipeline
     If ($Null -ne $Content) {
-        # Match version number from the download URL
-        # Content returned is a string - trim blank lines, split at line ends, sort and select first object to get version number
-        $Sort = $Content.Trim().Split("\n") | Sort-Object | Select-Object -First 1
-        If ($Sort -match $res.Get.MatchVersion) {
-            $Version = $Matches[0]
-        }
-        Else {
-            $Version = "Unknown"
-        }
-
-        # Construct the output; Return the custom object to the pipeline
         $PSObject = [PSCustomObject] @{
-            Version = $Version
+            Version = [RegEx]::Match($Content, $res.Get.MatchVersion).Captures.Groups[1].Value
             URI     = $res.Get.DownloadUri
         }
         Write-Output -InputObject $PSObject

--- a/Evergreen/Public/Get-Zoom.ps1
+++ b/Evergreen/Public/Get-Zoom.ps1
@@ -40,7 +40,7 @@ Function Get-Zoom {
             Version  = $Version
             Platform = "Windows"
             Type     = $installer.Name
-            URI      = $redirectUrl
+            URI      = [RegEx]::Match($redirectUrl, $res.Get.MatchUrl).Captures.Groups[1].Value
         }
         Write-Output -InputObject $PSObject
     }
@@ -65,7 +65,7 @@ Function Get-Zoom {
             Version  = $Version
             Platform = "Citrix"
             Type     = $installer.Name
-            URI      = $redirectUrl
+            URI      = [RegEx]::Match($redirectUrl, $res.Get.MatchUrl).Captures.Groups[1].Value
         }
         Write-Output -InputObject $PSObject
     }
@@ -75,7 +75,7 @@ Function Get-Zoom {
     ForEach ($installer in $res.Get.VMwareVDIUris.GetEnumerator()) {
 
         # Follow the download link which will return a 301/302
-        $redirectUrl = Resolve-RedirectedUri -Uri $res.Get.VMwareVDIUris[$installer.Key]
+        $redirectUrl = Resolve-Uri -Uri $res.Get.VMwareVDIUris[$installer.Key]
 
         # Match version number from the download URL
         If ($redirectUrl -match $res.Get.MatchVersion) {
@@ -90,7 +90,7 @@ Function Get-Zoom {
             Version  = $Version
             Platform = "VMware"
             Type     = $installer.Name
-            URI      = $redirectUrl
+            URI      = [RegEx]::Match($redirectUrl, $res.Get.MatchUrl).Captures.Groups[1].Value
         }
         Write-Output -InputObject $PSObject
     }


### PR DESCRIPTION
* Updates URL to current version for `TeamViewer`. New URL requires different approach to query
* Adds `Get-SystemNetRequest` that uses `System.Net.WebRequest` to make a HTTP request and return response
* Updates `Get-TeamViewer` to use `Get-SystemNetRequest` to retrieve version from updated URL. Updates code to return version and download URL as a result
* Updates `Get-Zoom` to use `Resolve-Uri` to follow download URLs and find version number. `Get-Zoom` now returns more versions numbers for Zoom downloads than previously. Updates RegEx approach to return version numbers from URLs