### PR TITLE
Development

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+## VERSION
+
+* Adds `ConvertFrom-GitHubReleasesJson` to standardise queries to GitHub repositories
+* Updates `Get-Atom`, `Get-BISF`, `Get-GitForWindows`, `Get-Greenshot`, `Get-MicrosoftPowerShellCore`, `Get-OpenJDK`, `Get-ShareX`, `Get-mRemoteNG` to use `ConvertFrom-GitHubReleasesJson`
+* Updates RegEx for version matching strings for `BISF`, `GitForWindows`, `ShareX`
+* Adds `Get-Architecture` and `Get-Platform` private functions
+* Adds `Get-GitHubRelease` to enable returning version and downloads from any GitHub repository. Use to get versions of applications on GitHub that aren't yet included in `Evergreen`
+
 ## 2004.134
 
 * Fixes an issue where `Get-Zoom` was still returning a URI to downloads with query strings attached.

--- a/Evergreen/Evergreen.psd1
+++ b/Evergreen/Evergreen.psd1
@@ -72,7 +72,7 @@ PowerShellVersion = '3.0'
 FunctionsToExport = @('Export-EvergreenFunctionStrings', 
                'Export-EvergreenResourceStrings', 'Get-AdobeAcrobatReaderDC', 
                'Get-Atom', 'Get-BISF', 'Get-CitrixAppLayeringFeed', 
-               'Get-CitrixApplicationDeliveryManagementFeed', 
+               'Get-CitrixApplicationDeliveryManagementFeed', 'Get-GitHubRelease',
                'Get-CitrixEndpointManagementFeed', 'Get-CitrixGatewayFeed', 
                'Get-CitrixHypervisorFeed', 'Get-CitrixLicensingFeed', 
                'Get-CitrixReceiverFeed', 'Get-CitrixSdwanFeed', 

--- a/Evergreen/Manifests/BISF.json
+++ b/Evergreen/Manifests/BISF.json
@@ -3,7 +3,8 @@
 	"Source": "https://eucweb.com/",
 	"Get": {
 		"Uri": "https://api.github.com/repos/EUCweb/BIS-F/releases/latest",
-		"ContentType": "application/json; charset=utf-8"
+		"ContentType": "application/json; charset=utf-8",
+		"MatchVersion": "(\\d+(\\.\\d+){1,4}).*"
 	},
 	"Install": {
 		"Setup": "AppName.*.exe",

--- a/Evergreen/Manifests/GitForWindows.json
+++ b/Evergreen/Manifests/GitForWindows.json
@@ -4,7 +4,7 @@
 	"Get": {
 		"Uri": "https://api.github.com/repos/git-for-windows/git/releases/latest",
 		"ContentType": "application/json; charset=utf-8",
-		"MatchVersion": "(?<=v)\\d+\\.\\d+\\.\\d+(?=\\.windows)"
+		"MatchVersion": "(\\d+(\\.\\d+){1,4}).*"
 	},
 	"Install": {
 		"Setup": "Git*.exe",

--- a/Evergreen/Manifests/GitHubRelease.json
+++ b/Evergreen/Manifests/GitHubRelease.json
@@ -1,0 +1,21 @@
+{
+	"Name": "GitHub release",
+	"Source": "https://github.com/",
+	"Get": {
+		"Uri": "",
+		"ContentType": "application/json; charset=utf-8",
+		"MatchVersion": "(\\d+(\\.\\d+){1,4}).*"
+	},
+	"Install": {
+		"Setup": "",
+		"Preinstall": "",
+		"Physical": {
+			"Arguments": "",
+			"PostInstall": []
+		},
+		"Virtual": {
+			"Arguments": "",
+			"PostInstall": []
+		}
+	}
+}

--- a/Evergreen/Manifests/ShareX.json
+++ b/Evergreen/Manifests/ShareX.json
@@ -3,7 +3,8 @@
 	"Source": "https://getsharex.com/",
 	"Get": {
 		"Uri": "https://api.github.com/repos/ShareX/ShareX/releases/latest",
-		"ContentType": "application/json; charset=utf-8"
+		"ContentType": "application/json; charset=utf-8",
+		"MatchVersion": "(\\d+(\\.\\d+){1,4}).*"
 	},
 	"Install": {
 		"Setup": "ShareX*.exe",

--- a/Evergreen/Private/ConvertFrom-GitHubReleasesJson.ps1
+++ b/Evergreen/Private/ConvertFrom-GitHubReleasesJson.ps1
@@ -19,11 +19,11 @@ Function ConvertFrom-GitHubReleasesJson {
     # Convert JSON string to a hashtable
     try {
         Write-Verbose -Message "$($MyInvocation.MyCommand): Converting from JSON string."
-        $release = $Content | ConvertFrom-Json
+        $release = ConvertFrom-Json -InputObject $Content
     }
-    catch [System.Exception] {
-        Write-Warning -Message "$($MyInvocation.MyCommand): failed to convert JSON string."
-        Throw $_.Exception.Message
+    catch {
+        Throw [System.Management.Automation.RuntimeException] "$($MyInvocation.MyCommand): Failed to convert JSON string."
+        Break
     }
     finally {
         # Ensure that we only have the latest release
@@ -44,9 +44,9 @@ Function ConvertFrom-GitHubReleasesJson {
                 "tarball_url", "target_commitish", "upload_url", "url", "zipball_url")
         $params = @{
             ReferenceObject  = $requiredProperties
-            DifferenceObject = (Get-Member -InputObject $release -MemberType NoteProperty) #$release.Keys
+            DifferenceObject = (Get-Member -InputObject $release -MemberType NoteProperty)
             PassThru         = $True
-            ErrorAction      = "SilentlyContinue"
+            ErrorAction      = $script:resourceStrings.Preferences.ErrorAction
         }
         $missingProperties = Compare-Object @params
         If ($Null -ne $missingProperties) {

--- a/Evergreen/Private/ConvertFrom-GitHubReleasesJson.ps1
+++ b/Evergreen/Private/ConvertFrom-GitHubReleasesJson.ps1
@@ -1,0 +1,80 @@
+Function ConvertFrom-GitHubReleasesJson {
+    <#
+        .SYNOPSIS
+            Validates a JSON string returned from a GitHub releases API and returns a formatted object
+            Example: https://api.github.com/repos/PowerShell/PowerShell/releases/latest
+    #>
+    [OutputType([System.Management.Automation.PSObject])]
+    [CmdletBinding()]
+    Param(
+        [Parameter(Mandatory = $True, Position = 0)]
+        [ValidateNotNullOrEmpty()]
+        [System.String] $Content,
+
+        [Parameter(Mandatory = $True, Position = 1)]
+        [ValidateNotNullOrEmpty()]
+        [System.String] $MatchVersion
+    )
+
+    # Convert JSON string to a hashtable
+    try {
+        Write-Verbose -Message "$($MyInvocation.MyCommand): Converting from JSON string."
+        $release = $Content | ConvertFrom-Json
+    }
+    catch [System.Exception] {
+        Write-Warning -Message "$($MyInvocation.MyCommand): failed to convert JSON string."
+        Throw $_.Exception.Message
+    }
+    finally {
+        # Ensure that we only have the latest release
+        If ($release.Count -gt 1) {
+            try {
+                Write-Warning -Message "$($MyInvocation.MyCommand): More than one release retrieved from GitHub."
+                $release = $release | Where-Object { $_.prerelease -eq $False } | Select-Object -First 1
+            }
+            catch {
+                Throw [System.Management.Automation.RuntimeException] "$($MyInvocation.MyCommand): Failed to filter to latest release."
+            }
+        }
+
+        # Validate that $release has the expected properties
+        Write-Verbose -Message "$($MyInvocation.MyCommand): Validating GitHub release object."
+        $requiredProperties = @("assets", "assets_url", "author", "body", "created_at", "draft", `
+                "html_url", "id", "name", "node_id", "prerelease", "published_at", "tag_name", `
+                "tarball_url", "target_commitish", "upload_url", "url", "zipball_url")
+        $params = @{
+            ReferenceObject  = $requiredProperties
+            DifferenceObject = (Get-Member -InputObject $release -MemberType NoteProperty) #$release.Keys
+            PassThru         = $True
+            ErrorAction      = "SilentlyContinue"
+        }
+        $missingProperties = Compare-Object @params
+        If ($Null -ne $missingProperties) {
+            Write-Verbose -Message "$($MyInvocation.MyCommand): Validated successfully."
+            $validate = $True
+        }
+        Else {
+            Write-Verbose -Message "$($MyInvocation.MyCommand): Validation failed."
+            $validate = $False
+            $missingProperties | ForEach-Object {
+                Throw [System.Management.Automation.ValidationMetadataException] "$($MyInvocation.MyCommand): Property: '$_' missing"
+            }
+        }
+
+        # Build and array of the latest release and download URLs
+        If ($validate) {
+            ForEach ($asset in $release.assets) {
+                Write-Verbose -Message "$($MyInvocation.MyCommand): Building output object."
+                $PSObject = [PSCustomObject] @{
+                    Version      = [RegEx]::Match($release.tag_name, $MatchVersion).Captures.Groups[1].Value
+                    Platform     = (Get-Platform -String $asset.browser_download_url)
+                    Architecture = (Get-Architecture -String $asset.browser_download_url)
+                    Date         = (ConvertTo-DateTime -DateTime $release.created_at)
+                    Size         = $asset.size
+                    URI          = $asset.browser_download_url
+                }
+                Write-Output -InputObject $PSObject
+            }
+        }
+    }
+}

--- a/Evergreen/Private/Get-Architecture.ps1
+++ b/Evergreen/Private/Get-Architecture.ps1
@@ -15,7 +15,7 @@ Function Get-Architecture {
         "x64" { $architecture = "x64" }
         "-x86" { $architecture = "x86" }
         "fxdependent" { $architecture = "fxdependent" }
-        Default { $architecture = "Unknown" }
+        Default { $architecture = "x86" }
     }
     Write-Verbose -Message "$($MyInvocation.MyCommand): Found $architecture."
     Write-Output -InputObject $architecture

--- a/Evergreen/Private/Get-Architecture.ps1
+++ b/Evergreen/Private/Get-Architecture.ps1
@@ -1,0 +1,22 @@
+Function Get-Architecture {
+    [OutputType([System.String])]
+    [CmdletBinding()]
+    Param(
+        [Parameter(Mandatory = $True, Position = 0)]
+        [ValidateNotNullOrEmpty()]
+        [System.String] $String
+    )
+
+    Switch -Regex ($String) {
+        "amd64" { $architecture = "AMD64" }
+        "arm64" { $architecture = "ARM64" }
+        "arm32" { $architecture = "ARM32" }
+        "x86_64" { $architecture = "x86_64" }
+        "x64" { $architecture = "x64" }
+        "-x86" { $architecture = "x86" }
+        "fxdependent" { $architecture = "fxdependent" }
+        Default { $architecture = "Unknown" }
+    }
+    Write-Verbose -Message "$($MyInvocation.MyCommand): Found $architecture."
+    Write-Output -InputObject $architecture
+}

--- a/Evergreen/Private/Get-Platform.ps1
+++ b/Evergreen/Private/Get-Platform.ps1
@@ -1,0 +1,22 @@
+Function Get-Platform {
+    [OutputType([System.String])]
+    [CmdletBinding()]
+    Param(
+        [Parameter(Mandatory = $True, Position = 0)]
+        [ValidateNotNullOrEmpty()]
+        [System.String] $String
+    )
+
+    Switch -Regex ($String) {
+        "rhel" { $platform = "RHEL" }
+        "linux" { $platform = "Linux" }
+        "win" { $platform = "Windows" }
+        "osx" { $platform = "macOS" }
+        "debian" { $platform = "Debian" }
+        "ubuntu" { $platform = "Ubuntu" }
+        "centos" { $platform = "CentOS" }
+        Default { $platform = "Unknown" }
+    }
+    Write-Verbose -Message "$($MyInvocation.MyCommand): Found $platform."
+    Write-Output -InputObject $platform
+}

--- a/Evergreen/Private/Get-Platform.ps1
+++ b/Evergreen/Private/Get-Platform.ps1
@@ -9,13 +9,15 @@ Function Get-Platform {
 
     Switch -Regex ($String) {
         "rhel" { $platform = "RHEL" }
-        "linux" { $platform = "Linux" }
-        "win" { $platform = "Windows" }
-        "osx" { $platform = "macOS" }
-        "debian" { $platform = "Debian" }
+        "\.rpm" { $platform = "RedHat" }
+        "\.tar.gz|linux" { $platform = "Linux" }
+        "\.nupkg" { $platform = "NuGet" }
+        "mac|osx" { $platform = "macOS" }
+        "\.deb|debian" { $platform = "Debian" }
         "ubuntu" { $platform = "Ubuntu" }
         "centos" { $platform = "CentOS" }
-        Default { $platform = "Unknown" }
+        "\.exe|\.msi|windows|win" { $platform = "Windows" }
+        Default { $platform = "Windows" }
     }
     Write-Verbose -Message "$($MyInvocation.MyCommand): Found $platform."
     Write-Output -InputObject $platform

--- a/Evergreen/Private/Invoke-WebContent.ps1
+++ b/Evergreen/Private/Invoke-WebContent.ps1
@@ -49,6 +49,8 @@ Function Invoke-WebContent {
         $errorAction = "SilentlyContinue"
     }
 
+    # Trust certificate used by the remote server (typically self-sign certs)
+    # TODO: Get this to work on PowerShell Core
     If ($TrustCertificate.IsPresent) {
         If (Test-PSCore) {
             Write-Warning -Message "$($MyInvocation.MyCommand): Running PowerShell Core. Skipping System.Security.Cryptography.X509Certificates."

--- a/Evergreen/Public/Get-Atom.ps1
+++ b/Evergreen/Public/Get-Atom.ps1
@@ -27,57 +27,14 @@ Function Get-Atom {
     $res = Get-FunctionResource -AppName ("$($MyInvocation.MyCommand)".Split("-"))[1]
     Write-Verbose -Message $res.Name
 
-    # Get latest version and download latest Atom release via GitHub API
-    # Query the Atom repository for releases, keeping the latest stable release
+    # Get latest version and download latest release via GitHub API
     $iwcParams = @{
         Uri         = $res.Get.Uri
         ContentType = $res.Get.ContentType
-        Raw         = $True
     }
     $Content = Invoke-WebContent @iwcParams
 
-    If ($Null -ne $Content) {
-        $json = $Content | ConvertFrom-Json
-        $releases = $json | Where-Object { $_.prerelease -ne $True }
-        $latestRelease = $releases | Select-Object -First 1
-
-        # Build the output object with release details
-        ForEach ($release in $latestRelease.assets) {
-
-            If ($release.browser_download_url -match $res.Get.MatchExtensions) {
-                Switch -Regex ($release.browser_download_url) {
-                    "amd64" { $arch = "AMD64" }
-                    "arm64" { $arch = "ARM64" }
-                    "arm32" { $arch = "ARM32" }
-                    "x86_64" { $arch = "x86_64" }
-                    "x64" { $arch = "x64" }
-                    "x86" { $arch = "x86" }
-                    Default { $arch = "x86" }
-                }
-
-                Switch -Regex ($release.browser_download_url) {
-                    "rpm" { $platform = "RHEL" }
-                    "win" { $platform = "Windows" }
-                    "exe" { $platform = "Windows" }
-                    "mac" { $platform = "macOS" }
-                    "deb" { $platform = "Debian" }
-                    Default { $platform = "Unknown" }
-                }
-
-                # Match version number
-                $latestRelease.tag_name -match $res.Get.MatchVersion | Out-Null
-                $Version = $Matches[0]
-
-                $PSObject = [PSCustomObject] @{
-                    Version      = $Version
-                    Platform     = $platform
-                    Architecture = $arch
-                    Date         = (ConvertTo-DateTime -DateTime $release.created_at)
-                    Size         = $release.size
-                    URI          = $release.browser_download_url
-                }
-                Write-Output -InputObject $PSObject
-            }
-        }
-    }
+    # Convert the returned release data into a useable object with Version, URI etc.
+    $object = ConvertFrom-GitHubReleasesJson -Content $Content -MatchVersion $res.Get.MatchVersion
+    Write-Output -InputObject $object
 }

--- a/Evergreen/Public/Get-BISF.ps1
+++ b/Evergreen/Public/Get-BISF.ps1
@@ -27,27 +27,14 @@ Function Get-BISF {
     $res = Get-FunctionResource -AppName ("$($MyInvocation.MyCommand)".Split("-"))[1]
     Write-Verbose -Message $res.Name
 
-    # Query the BIS-F repository for releases, keeping the latest release
+    # Get latest version and download latest release via GitHub API
     $iwcParams = @{
         Uri         = $res.Get.Uri
         ContentType = $res.Get.ContentType
     }
     $Content = Invoke-WebContent @iwcParams
 
-    If ($Null -ne $Content) {
-        $json = $Content | ConvertFrom-Json
-        $releases = $json | Where-Object { $_.prerelease -ne $True }
-        $latestRelease = $releases | Select-Object -First 1
-
-        # Build and array of the latest release and download URLs
-        ForEach ($release in $latestRelease.assets) {
-            $PSObject = [PSCustomObject] @{
-                Version = $latestRelease.tag_name
-                Date    = (ConvertTo-DateTime -DateTime $release.created_at)
-                Size    = $release.size
-                URI     = $release.browser_download_url
-            }
-            Write-Output -InputObject $PSObject
-        }
-    }
+    # Convert the returned release data into a useable object with Version, URI etc.
+    $object = ConvertFrom-GitHubReleasesJson -Content $Content -MatchVersion $res.Get.MatchVersion
+    Write-Output -InputObject $object
 }

--- a/Evergreen/Public/Get-GitHubRelease.ps1
+++ b/Evergreen/Public/Get-GitHubRelease.ps1
@@ -1,0 +1,48 @@
+Function Get-GitHubRelease {
+    <#
+        .SYNOPSIS
+            Returns latest version and URI from a GitHub repository release list.
+
+        .DESCRIPTION
+            Returns latest version and URI from a GitHub repository release list.
+
+            The releases URI is expected in the following format: https://api.github.com/repos/<account>/<repository>/releases/latest.
+            
+            More information on the GitHub releases API can be found here: https://developer.github.com/v3/repos/releases/.
+
+        .NOTES
+            Author: Aaron Parker
+            Twitter: @stealthpuppy
+        
+        .LINK
+            https://github.com/aaronparker/Evergreen
+
+        .EXAMPLE
+            Get-GitHubRelease -Uri "https://api.github.com/repos/Open-Shell/Open-Shell-Menu/releases/latest"
+
+            Description:
+            Returns version and download URIs from the supplied GitHub repository.
+    #>
+    [OutputType([System.Management.Automation.PSObject])]
+    [CmdletBinding()]
+    Param(
+        [Parameter(Mandatory = $True, Position = 0)]
+        [ValidateNotNullOrEmpty()]
+        [System.String] $Uri
+    )
+
+    # Get application resource strings from its manifest
+    $res = Get-FunctionResource -AppName ("$($MyInvocation.MyCommand)".Split("-"))[1]
+    Write-Verbose -Message $res.Name
+
+    # Get latest version and download latest release via GitHub API
+    $iwcParams = @{
+        Uri         = $Uri
+        ContentType = $res.Get.ContentType
+    }
+    $Content = Invoke-WebContent @iwcParams
+
+    # Convert the returned release data into a useable object with Version, URI etc.
+    $object = ConvertFrom-GitHubReleasesJson -Content $Content -MatchVersion $res.Get.MatchVersion
+    Write-Output -InputObject $object
+}

--- a/Evergreen/Public/Get-GitHubRelease.ps1
+++ b/Evergreen/Public/Get-GitHubRelease.ps1
@@ -21,19 +21,22 @@ Function Get-GitHubRelease {
             Get-GitHubRelease -Uri "https://api.github.com/repos/Open-Shell/Open-Shell-Menu/releases/latest"
 
             Description:
-            Returns version and download URIs from the supplied GitHub repository.
+            Returns version and download URIs from the supplied GitHub repository URL.
     #>
     [OutputType([System.Management.Automation.PSObject])]
     [CmdletBinding()]
     Param(
-        [Parameter(Mandatory = $True, Position = 0)]
-        [ValidateNotNullOrEmpty()]
-        [System.String] $Uri
+        [Parameter(Mandatory = $False, Position = 0)]
+        [System.String] $Uri = "https://api.github.com/repos/atom/atom/releases/latest"
     )
 
     # Get application resource strings from its manifest
     $res = Get-FunctionResource -AppName ("$($MyInvocation.MyCommand)".Split("-"))[1]
-    Write-Verbose -Message $res.Name
+
+    # If -Uri isn't used, we'll use the default value to show at least something
+    If (-not($PSBoundParameters.ContainsKey('Uri'))) {
+        Write-Warning -Message "$($MyInvocation.MyCommand): -Uri parameter not specified. Using the default repository."
+    }
 
     # Get latest version and download latest release via GitHub API
     $iwcParams = @{

--- a/Evergreen/Public/Get-GitforWindows.ps1
+++ b/Evergreen/Public/Get-GitforWindows.ps1
@@ -28,28 +28,14 @@ Function Get-GitForWindows {
     $res = Get-FunctionResource -AppName ("$($MyInvocation.MyCommand)".Split("-"))[1]
     Write-Verbose -Message $res.Name
 
-    # Query the Git repository for releases, keeping the latest release
+    # Get latest version and download latest release via GitHub API
     $iwcParams = @{
         Uri         = $res.Get.Uri
         ContentType = $res.Get.ContentType
     }
     $Content = Invoke-WebContent @iwcParams
 
-    If ($Null -ne $Content) {
-        $json = $Content | ConvertFrom-Json
-        $latestRelease = $json | Where-Object { $_.prerelease -ne $True } | Select-Object -First 1
-        $regexMatch = [Regex]::Match($latestRelease.tag_name, $res.Get.MatchVersion)
-        $version = if ($regexMatch.Success) { $regexMatch.Value } else { 'Unknown' }
-
-        # Build and array of the latest release and download URLs
-        ForEach ($release in $latestRelease.assets) {
-            $PSObject = [PSCustomObject] @{
-                Version = $version
-                Date    = (ConvertTo-DateTime -DateTime $release.created_at)
-                Size    = $release.size
-                URI     = $release.browser_download_url
-            }
-            Write-Output -InputObject $PSObject
-        }
-    }
+    # Convert the returned release data into a useable object with Version, URI etc.
+    $object = ConvertFrom-GitHubReleasesJson -Content $Content -MatchVersion $res.Get.MatchVersion
+    Write-Output -InputObject $object
 }

--- a/Evergreen/Public/Get-Greenshot.ps1
+++ b/Evergreen/Public/Get-Greenshot.ps1
@@ -27,33 +27,14 @@ Function Get-Greenshot {
     $res = Get-FunctionResource -AppName ("$($MyInvocation.MyCommand)".Split("-"))[1]
     Write-Verbose -Message $res.Name
 
-    # Query the Greenshot repository for releases, keeping the latest release
+    # Get latest version and download latest release via GitHub API
     $iwcParams = @{
         Uri         = $res.Get.Uri
         ContentType = $res.Get.ContentType
     }
     $Content = Invoke-WebContent @iwcParams
 
-    If ($Null -ne $Content) {
-        $json = $Content | ConvertFrom-Json
-        $releases = $json | Where-Object { $_.prerelease -ne $True }
-        $latestRelease = $releases | Select-Object -First 1
-
-        # Latest version number 'Greenshot-RELEASE-1.2.10.6'
-        $latestRelease.tag_name -match $res.Get.MatchVersion | Out-Null
-        $latestVersion = $Matches[0]
-
-        # Build and array of the latest release and download URLs
-        $releases = $latestRelease.assets | Where-Object { $_.name -like "Greenshot*" }
-        ForEach ($release in $releases) {
-            $PSObject = [PSCustomObject] @{
-                Version = $latestVersion
-                Date    = (ConvertTo-DateTime -DateTime $release.created_at)
-                Size    = $release.size
-                URI     = $release.browser_download_url
-            }
-            Write-Output -InputObject $PSObject
-        }
-    }
+    # Convert the returned release data into a useable object with Version, URI etc.
+    $object = ConvertFrom-GitHubReleasesJson -Content $Content -MatchVersion $res.Get.MatchVersion
+    Write-Output -InputObject $object
 }
-

--- a/Evergreen/Public/Get-MicrosoftPowerShellCore.ps1
+++ b/Evergreen/Public/Get-MicrosoftPowerShellCore.ps1
@@ -32,53 +32,10 @@ Function Get-MicrosoftPowerShellCore {
     $iwcParams = @{
         Uri         = $res.Get.Uri
         ContentType = $res.Get.ContentType
-        Raw         = $True
     }
     $Content = Invoke-WebContent @iwcParams
 
-    If ($Null -ne $Content) {
-        $json = $Content | ConvertFrom-Json
-        $releases = $json | Where-Object { $_.prerelease -ne $True }
-        $latestRelease = $releases | Select-Object -First 1
-
-        # Build the output object with release details
-        ForEach ($release in $latestRelease.assets) {
-
-            Switch -Regex ($release.browser_download_url) {
-                "amd64" { $arch = "AMD64" }
-                "arm64" { $arch = "ARM64" }
-                "arm32" { $arch = "ARM32" }
-                "x86_64" { $arch = "x86_64" }
-                "x64" { $arch = "x64" }
-                "-x86" { $arch = "x86" }
-                "fxdependent" { $arch = "fxdependent" }
-                Default { $arch = "Unknown" }
-            }
-
-            Switch -Regex ($release.browser_download_url) {
-                "rhel" { $platform = "RHEL" }
-                "linux" { $platform = "Linux" }
-                "win" { $platform = "Windows" }
-                "osx" { $platform = "macOS" }
-                "debian" { $platform = "Debian" }
-                "ubuntu" { $platform = "Ubuntu" }
-                Default { $platform = "Unknown" }
-            }
-
-            # Match version number
-            $latestRelease.tag_name -match $res.Get.MatchVersion | Out-Null
-            $Version = $Matches[0]
-
-            # Build and array of the latest release and download URLs
-            $PSObject = [PSCustomObject] @{
-                Version      = $Version
-                Platform     = $platform
-                Architecture = $arch
-                Date         = (ConvertTo-DateTime -DateTime $release.created_at)
-                Size         = $release.size
-                URI          = $release.browser_download_url
-            }
-            Write-Output -InputObject $PSObject
-        }
-    }
+    # Convert the returned release data into a useable object with Version, URI etc.
+    $object = ConvertFrom-GitHubReleasesJson -Content $Content -MatchVersion $res.Get.MatchVersion
+    Write-Output -InputObject $object
 }

--- a/Evergreen/Public/Get-MicrosoftPowerShellCore.ps1
+++ b/Evergreen/Public/Get-MicrosoftPowerShellCore.ps1
@@ -27,8 +27,7 @@ Function Get-MicrosoftPowerShellCore {
     $res = Get-FunctionResource -AppName ("$($MyInvocation.MyCommand)".Split("-"))[1]
     Write-Verbose -Message $res.Name
 
-    # Get latest version and download latest PowerShell Core release via GitHub API
-    # Query the PowerShell Core repository for releases, keeping the latest stable release
+    # Get latest version and download latest release via GitHub API
     $iwcParams = @{
         Uri         = $res.Get.Uri
         ContentType = $res.Get.ContentType

--- a/Evergreen/Public/Get-OpenJDK.ps1
+++ b/Evergreen/Public/Get-OpenJDK.ps1
@@ -27,60 +27,14 @@ Function Get-OpenJDK {
     $res = Get-FunctionResource -AppName ("$($MyInvocation.MyCommand)".Split("-"))[1]
     Write-Verbose -Message $res.Name    
 
-    # Get latest version and download latest Open JDK release via GitHub API
-    # Query the Open JDK repository for releases, keeping the latest stable release
+    # Get latest version and download latest release via GitHub API
     $iwcParams = @{
         Uri         = $res.Get.Uri
         ContentType = $res.Get.ContentType
-        Raw         = $True
     }
     $Content = Invoke-WebContent @iwcParams
 
-    If ($Null -ne $Content) {
-        $json = $Content | ConvertFrom-Json
-        $releases = $json | Where-Object { $_.prerelease -ne $True }
-        $latestRelease = $releases | Select-Object -First 1
-
-        # Build the output object with release details
-        ForEach ($release in $latestRelease.assets) {
-
-            # Match architecture and platform from the URL string
-            If ($release.browser_download_url -match "\.zip$|\.msi$") {
-                Switch -Regex ($release.browser_download_url) {
-                    "amd64" { $arch = "AMD64" }
-                    "arm64" { $arch = "ARM64" }
-                    "arm32" { $arch = "ARM32" }
-                    "x86_64" { $arch = "x86_64" }
-                    "x64" { $arch = "x64" }
-                    "-x86" { $arch = "x86" }
-                    "fxdependent" { $arch = "fxdependent" }
-                    Default { $arch = "Unknown" }
-                }
-                Switch -Regex ($release.browser_download_url) {
-                    "rhel" { $platform = "RHEL" }
-                    "linux" { $platform = "Linux" }
-                    "win" { $platform = "Windows" }
-                    "osx" { $platform = "macOS" }
-                    "debian" { $platform = "Debian" }
-                    "ubuntu" { $platform = "Ubuntu" }
-                    Default { $platform = "Unknown" }
-                }
-
-                # Match version number
-                $latestRelease.tag_name -match $res.Get.MatchVersion | Out-Null
-                $Version = $Matches[1]
-
-                # Construct the output; Return the custom object to the pipeline
-                $PSObject = [PSCustomObject] @{
-                    Version      = $Version
-                    Platform     = $platform
-                    Architecture = $arch
-                    Date         = (ConvertTo-DateTime -DateTime $release.created_at)
-                    Size         = $release.size
-                    URI          = $release.browser_download_url
-                }
-                Write-Output -InputObject $PSObject
-            }
-        }
-    }
+    # Convert the returned release data into a useable object with Version, URI etc.
+    $object = ConvertFrom-GitHubReleasesJson -Content $Content -MatchVersion $res.Get.MatchVersion
+    Write-Output -InputObject $object
 }

--- a/Evergreen/Public/Get-mRemoteNG.ps1
+++ b/Evergreen/Public/Get-mRemoteNG.ps1
@@ -27,39 +27,14 @@ Function Get-mRemoteNG {
     $res = Get-FunctionResource -AppName ("$($MyInvocation.MyCommand)".Split("-"))[1]
     Write-Verbose -Message $res.Name    
 
-    # Query the mRemoteNG repository for releases, keeping the latest release
+    # Get latest version and download latest release via GitHub API
     $iwcParams = @{
         Uri         = $res.Get.Uri
         ContentType = $res.Get.ContentType
     }
     $Content = Invoke-WebContent @iwcParams
 
-    # If something is returned
-    If ($Null -ne $Content) {
-        $json = $Content | ConvertFrom-Json
-        $releases = $json | Where-Object { $_.prerelease -ne $True }
-        $latestRelease = $releases | Select-Object -First 1
-
-        # Match version number
-        $latestRelease.tag_name -match $res.Get.MatchVersion | Out-Null
-        $Version = $Matches[0]
-
-        # Build an array of the latest release and download URLs
-        ForEach ($release in $latestRelease.assets) {
-            $PSObject = [PSCustomObject] @{
-                Version = $Version
-                Date    = (ConvertTo-DateTime -DateTime $release.created_at)
-                Size    = $release.size
-                URI     = $release.browser_download_url
-            }
-            Write-Output -InputObject $PSObject
-        }
-    }
-    Else {
-        Write-Warning -Message "$($MyInvocation.MyCommand): Check update URL: $($res.Get.Uri)."
-        $PSObject = [PSCustomObject] @{
-            Error = "Check update URL"
-        }
-        Write-Output -InputObject $PSObject
-    }
+    # Convert the returned release data into a useable object with Version, URI etc.
+    $object = ConvertFrom-GitHubReleasesJson -Content $Content -MatchVersion $res.Get.MatchVersion
+    Write-Output -InputObject $object
 }


### PR DESCRIPTION
* Adds `ConvertFrom-GitHubReleasesJson` to standardise queries to GitHub repositories
* Updates `Get-Atom`, `Get-BISF`, `Get-GitForWindows`, `Get-Greenshot`, `Get-MicrosoftPowerShellCore`, `Get-OpenJDK`, `Get-ShareX`, `Get-mRemoteNG` to use `ConvertFrom-GitHubReleasesJson`
* Updates RegEx for version matching strings for `BISF`, `GitForWindows`, `ShareX`
* Adds `Get-Architecture` and `Get-Platform` private functions
* Adds `Get-GitHubRelease` to enable returning version and downloads from any GitHub repository. Use to get versions of applications on GitHub that aren't yet included in `Evergreen`