### PR TITLE
Development

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Change Log
 
+## VERSION
+
 ## 2004.147
 
 * Adds `Get-Handbrake`, `Get-KeePass`, `Get-OpenShellMenu`, `Get-VastLimitsUberAgent`, `Get-WinSCP`

--- a/Evergreen/Evergreen.psd1
+++ b/Evergreen/Evergreen.psd1
@@ -27,10 +27,10 @@ Author = 'Aaron Parker; Bronson Magnan; Trond Eric Haarvarstein'
 CompanyName = 'stealthpuppy, Bronson Magnan, xenappblog'
 
 # Copyright statement for this module
-Copyright = '(c) 2019 stealthpuppy, Bronson Magnan, xenappblog. All rights reserved.'
+Copyright = '(c) 2020 stealthpuppy, Bronson Magnan, xenappblog. All rights reserved.'
 
 # Description of the functionality provided by this module
-Description = 'Evergreen is a simple PowerShell module to get latest version numbers and download URLs for various software products. The module consists of Get commands to use in scripts when performing software management tasks.'
+Description = 'Create evergeen Windows image build scripts with the latest versions of applications. Evergreen is a simple PowerShell module to get latest version numbers and download URLs for various software products. The module consists of Get commands to use in scripts when performing software management tasks.'
 
 # Minimum version of the Windows PowerShell engine required by this module
 PowerShellVersion = '3.0'
@@ -76,7 +76,7 @@ FunctionsToExport = @('Export-EvergreenFunctionStrings',
                'Get-CitrixApplicationDeliveryManagementFeed', 
                'Get-CitrixEndpointManagementFeed', 'Get-CitrixGatewayFeed', 
                'Get-CitrixHypervisorFeed', 'Get-CitrixLicensingFeed', 
-               'Get-CitrixReceiverFeed', 'Get-CitrixSdwanFeed', 
+               'Get-CitrixReceiverFeed', 'Get-CitrixSdwanFeed', 'Get-dnGrep',
                'Get-CitrixVirtualAppsDesktopsFeed', 'Get-CitrixWorkspaceApp', 
                'Get-CitrixWorkspaceAppFeed', 'Get-CitrixXenServerTools', 
                'Get-ControlUpAgent', 'Get-Cyberduck', 'Get-FileZilla', 
@@ -121,7 +121,7 @@ PrivateData = @{
     PSData = @{
 
         # Tags applied to this module. These help with module discovery in online galleries.
-        Tags = 'Firefox','AdobeReader','Chrome','Receiver','Paint.NET','CitrixReceiver','CitrixWorkspace','Zoom','VMwareTools','VLCPlayer','VirtualBox','PowerShell','LibreOffice','FileZilla','ControlUp','XenServer'
+        Tags = 'Evergreen', 'Packer', 'Automation', 'MDT', 'ConfigMgr'
 
         # A URL to the license for this module.
         LicenseUri = 'https://github.com/aaronparker/Evergreen/blob/master/LICENSE'

--- a/Evergreen/Evergreen.psd1
+++ b/Evergreen/Evergreen.psd1
@@ -72,7 +72,7 @@ PowerShellVersion = '3.0'
 FunctionsToExport = @('Export-EvergreenFunctionStrings', 
                'Export-EvergreenResourceStrings', 'Get-7zip', 
                'Get-AdobeAcrobatReaderDC', 'Get-Atom', 'Get-BISF', 
-               'Get-CitrixAppLayeringFeed', 
+               'Get-CitrixAppLayeringFeed', 'Get-MicrosoftWvdInfraAgent',
                'Get-CitrixApplicationDeliveryManagementFeed', 
                'Get-CitrixEndpointManagementFeed', 'Get-CitrixGatewayFeed', 
                'Get-CitrixHypervisorFeed', 'Get-CitrixLicensingFeed', 

--- a/Evergreen/Manifests/CitrixWorkspaceApp.json
+++ b/Evergreen/Manifests/CitrixWorkspaceApp.json
@@ -3,8 +3,7 @@
 	"Source": "https://www.citrix.com/downloads/workspace-app/",
 	"Get": {
 		"Uri": {
-			"Windows": "https://downloadplugins.citrix.com/ReceiverUpdates/Prod/catalog_win.xml",
-			"MacOS": "https://downloadplugins.citrix.com/ReceiverUpdates/Prod/catalog_macos.xml"
+			"Windows": "https://downloadplugins.citrix.com/ReceiverUpdates/Prod/catalog_win.xml"
 		},
 		"UserAgent": "CitrixReceiver/19.7.0.15 WinOS/10.0.18362",
 		"DownloadUri": "https://downloadplugins.citrix.com/ReceiverUpdates/Prod",

--- a/Evergreen/Manifests/GoogleChrome.json
+++ b/Evergreen/Manifests/GoogleChrome.json
@@ -1,18 +1,13 @@
 {
 	"Name": "Google Chrome",
-	"Source": "http://www.google.com/chrome",
+	"Source": "https://cloud.google.com/chrome-enterprise/browser/download/",
 	"Get": {
 		"Uri": "https://omahaproxy.appspot.com/all.json",
 		"DownloadUri": "https://dl.google.com",
-		"Channels": [
-			"stable"
-		],
-		"Downloads": {
-			"win64": "/dl/chrome/install/googlechromestandaloneenterprise64.msi",
-			"win64beta": "/dl/chrome/install/beta/googlechromebetastandaloneenterprise64.msi",
+		"Channel": "stable",
+		"Platforms": {
 			"win": "/dl/chrome/install/googlechromestandaloneenterprise.msi",
-			"winbeta": "/dl/chrome/install/beta/googlechromebetastandaloneenterprise.msi",
-			"mac": "/chrome/mac/stable/GGRO/googlechrome.dmg"
+			"win64": "/dl/chrome/install/googlechromestandaloneenterprise64.msi"
 		}
 	},
 	"Install": {

--- a/Evergreen/Manifests/MicrosoftWvdInfraAgent.json
+++ b/Evergreen/Manifests/MicrosoftWvdInfraAgent.json
@@ -1,0 +1,22 @@
+{
+	"Name": "Microsoft Windows Virtual Desktop Infrastructure agent",
+	"Source": "https://docs.microsoft.com/azure/virtual-desktop/",
+	"Get": {
+		"Uri": "https://query.prod.cms.rt.microsoft.com/cms/api/am/binary/RWrmXv",
+		"MatchFilename": "(Microsoft.*msi)",
+		"MatchVersion": "(\\d+\\.){3}\\d+"
+	},
+	"Install": {
+		"Setup": "AppName.*.exe",
+		"Physical": {
+			"Arguments": "",
+			"PostInstall": [
+			]
+		},
+		"Virtual": {
+			"Arguments": "",
+			"PostInstall": [
+			]
+		}
+	}
+}

--- a/Evergreen/Manifests/OracleVirtualBox.json
+++ b/Evergreen/Manifests/OracleVirtualBox.json
@@ -5,7 +5,7 @@
 		"Uri": "https://download.virtualbox.org/virtualbox/LATEST.TXT",
 		"DownloadUri": "http://download.virtualbox.org/virtualbox/",
 		"MatchVersion": "(\\d+(\\.\\d+){1,4}).*",
-		"MatchExtensions": ".*Version.*(exe|dmg|rpm|deb)",
+		"MatchExtensions": ".*Version.*(exe)",
 		"MatchDownloadFile": "<a[^>]*>([^<]+)</a>"
 	},
 	"Install": {

--- a/Evergreen/Manifests/PaintDotNet.json
+++ b/Evergreen/Manifests/PaintDotNet.json
@@ -3,19 +3,24 @@
 	"Source": "https://getpaint.net",
 	"Get": {
 		"Uri": "https://www.getpaint.net/updates/versions.8.1000.0.x64.en.txt",
-		"MatchVersion": "StableVersions=(\\d+(\\.\\d+)+\\s)",
-		"MatchDownload": "#Version_FullZipUrlList=(.*)"
+		"VersionProperty": "StableVersions",
+		"UrlProperty": "_ZipUrlList",
+		"UrlDelimiter": ","
 	},
 	"Install": {
 		"Setup": "paint*.zip",
 		"Preinstall": "Expand-Archive -Path #FileName -DestinationPath #TempPath",
 		"Physical": {
 			"Arguments": "CHECKFORUPDATES=1 DESKTOPSHORTCUT=0",
-			"PostInstall": []
+			"PostInstall": [
+
+			]
 		},
 		"Virtual": {
 			"Arguments": "CHECKFORUPDATES=0 DESKTOPSHORTCUT=0",
-			"PostInstall": []
+			"PostInstall": [
+
+			]
 		}
 	}
 }

--- a/Evergreen/Manifests/VideoLanVlcPlayer.json
+++ b/Evergreen/Manifests/VideoLanVlcPlayer.json
@@ -6,22 +6,17 @@
 			"Windows": {
 				"x64": "https://update.videolan.org/vlc/status-win-x64",
 				"x86": "https://update.videolan.org/vlc/status-win-x86"
-			},
-			"macOS": "http://update.videolan.org/vlc/sparkle/vlc-intel64.xml"
+			}
 		},
 		"ContentType": "application/octet-stream",
 		"UserAgent": "VLC/3.0.7 LibVLC/3.0.7",
 		"XmlNode": "//item",
 		"TrimVersion": "Version ",
-		"DownloadUriMacOS": "https://get.videolan.org/vlc/#version/macosx/vlc-#version.dmg",
 		"Extensions": {
 			"Windows": [
 				"EXE",
 				"MSI",
 				"ZIP"
-			],
-			"macOS": [
-				"DMG"
 			]
 		}
 	},

--- a/Evergreen/Manifests/dnGrep.json
+++ b/Evergreen/Manifests/dnGrep.json
@@ -1,0 +1,23 @@
+{
+	"Name": "dnGrep",
+	"Source": "http://dngrep.github.io/",
+	"Get": {
+		"Uri": "https://api.github.com/repos/dnGrep/dnGrep/releases/latest",
+		"ContentType": "application/json; charset=utf-8",
+		"MatchVersion": "(\\d+(\\.\\d+){1,4}).*"
+	},
+	"Install": {
+		"Setup": "AppName.*.exe",
+		"Preinstall": "",
+		"Physical": {
+			"Arguments": "",
+			"PostInstall": [
+			]
+		},
+		"Virtual": {
+			"Arguments": "",
+			"PostInstall": [
+			]
+		}
+	}
+}

--- a/Evergreen/Private/Get-Architecture.ps1
+++ b/Evergreen/Private/Get-Architecture.ps1
@@ -11,6 +11,8 @@ Function Get-Architecture {
         "amd64" { $architecture = "AMD64" }
         "arm64" { $architecture = "ARM64" }
         "arm32" { $architecture = "ARM32" }
+        "win32" { $architecture = "x86"; Break }
+        "win64" { $architecture = "x64"; Break }
         "x86_64" { $architecture = "x64"; Break }
         "x64" { $architecture = "x64"; Break }
         "-x86" { $architecture = "x86"; Break }

--- a/Evergreen/Private/Get-ModuleResource.ps1
+++ b/Evergreen/Private/Get-ModuleResource.ps1
@@ -14,7 +14,7 @@ Function Get-ModuleResource {
     
     try {
         Write-Verbose -Message "$($MyInvocation.MyCommand): read module resource strings from [$Path]"
-        $content = Get-Content -Path $Path -Raw -ErrorAction SilentlyContinue
+        $content = Get-Content -Path $Path -Raw -ErrorAction "SilentlyContinue"
     }
     catch [System.Exception] {
         Write-Warning -Message "$($MyInvocation.MyCommand): failed to read from: $Path."
@@ -23,10 +23,10 @@ Function Get-ModuleResource {
 
     try {
         If (Test-PSCore) {
-            $script:resourceStringsTable = $content | ConvertFrom-Json -AsHashtable -ErrorAction SilentlyContinue
+            $script:resourceStringsTable = $content | ConvertFrom-Json -AsHashtable -ErrorAction "SilentlyContinue"
         }
         Else {
-            $script:resourceStringsTable = $content | ConvertFrom-Json -ErrorAction SilentlyContinue | ConvertTo-Hashtable
+            $script:resourceStringsTable = $content | ConvertFrom-Json -ErrorAction "SilentlyContinue" | ConvertTo-Hashtable
         }
     }
     catch [System.Exception] {

--- a/Evergreen/Public/Get-AdobeAcrobatReaderDC.ps1
+++ b/Evergreen/Public/Get-AdobeAcrobatReaderDC.ps1
@@ -4,7 +4,7 @@ Function Get-AdobeAcrobatReaderDC {
             Gets the download URLs for Adobe Reader DC Continuous track installers.
 
         .DESCRIPTION
-            Gets the download URLs for Adobe Reader DC Continuous track installers for the latest version for Windows and macOS.
+            Gets the download URLs for Adobe Reader DC Continuous track installers for the latest version for Windows.
 
         .NOTES
             Author: Aaron Parker

--- a/Evergreen/Public/Get-ControlUpAgent.ps1
+++ b/Evergreen/Public/Get-ControlUpAgent.ps1
@@ -52,14 +52,9 @@ Function Get-ControlUpAgent {
                 Default { $dotnet = "Unknown" }
             }
 
-            # Extract the version number
-            # TODO update version regex to return a single group
-            $link.href -match $res.Get.MatchVersion | Out-Null
-            $version = $matches[0]
-
             # Build and array of the latest release and download URLs
             $PSObject = [PSCustomObject] @{
-                Version      = $version
+                Version      = [RegEx]::Match($link.href, $res.Get.MatchVersion).Captures.Value
                 Framework    = $dotnet
                 Architecture = $arch
                 URI          = $link.href

--- a/Evergreen/Public/Get-GoogleChrome.ps1
+++ b/Evergreen/Public/Get-GoogleChrome.ps1
@@ -13,28 +13,15 @@ Function Get-GoogleChrome {
         .LINK
             https://github.com/aaronparker/Evergreen
 
-        .PARAMETER Platform
-            Specify the platform/s to return versions for. Supports all available platforms - Windows, macOS.
-
         .EXAMPLE
             Get-GoogleChromeVersion
 
             Description:
-            Returns the available Google Chrome versions across all platforms and channels.
-
-        .EXAMPLE
-            Get-GoogleChromeVersion -Platform win64 -Channel stable
-
-            Description:
-            Returns the Google Chrome version for the current stable release on 64-bit Windows.
+            Returns the available Google Chrome versions and download URLs.
     #>
     [OutputType([System.Management.Automation.PSObject])]
     [CmdletBinding()]
-    Param (
-        [Parameter()]
-        [ValidateSet('win', 'win64', 'mac')]
-        [System.String[]] $Platform = @('win', 'win64', 'mac')
-    )
+    Param ()
 
     # Get application resource strings from its manifest
     $res = Get-FunctionResource -AppName ("$($MyInvocation.MyCommand)".Split("-"))[1]
@@ -43,26 +30,25 @@ Function Get-GoogleChrome {
     # Read the JSON and convert to a PowerShell object. Return the current release version of Chrome
     $Content = Invoke-WebContent -Uri $res.Get.Uri
 
-    # Read the JSON and build an array of platform, channel, version
     If ($Null -ne $Content) {
+        
+        # Convert the returned JSON content to an object
         $Json = $Content | ConvertFrom-Json
-        $releases = New-Object -TypeName System.Collections.ArrayList
-        ForEach ($os in $Json) {
-            $stable = $os.versions | Where-Object { $res.Get.Channels -contains $_.channel }
+
+        # Read the JSON and build an array of platform, channel, version
+        ForEach ($platform in $res.Get.Platforms.GetEnumerator()) {
+            Write-Verbose -Message "$($MyInvocation.MyCommand): $($platform.Name)."
+            $stable = $Json.versions | Where-Object { ($_.channel -eq $res.Get.Channel) -and ($_.os -eq $platform.Name) }  
             ForEach ($version in $stable) {
                 $PSObject = [PSCustomObject] @{
-                    Version  = $version.current_version
-                    Platform = $version.os
-                    Date     = ([DateTime]::ParseExact($version.current_reldate.Trim(), 'MM/dd/yy', [CultureInfo]::InvariantCulture))
-                    URI      = "$($res.Get.DownloadUri)$($res.Get.Downloads.$($version.os))"
+                    Version      = $version.current_version
+                    Architecture = Get-Architecture -String $version.os
+                    Date         = ConvertTo-DateTime -DateTime $version.current_reldate.Trim() -Pattern 'MM/dd/yy'
+                    URI          = "$($res.Get.DownloadUri)$($res.Get.Platforms[$platform.Key])"
                 }
-                $releases.Add($PSObject) | Out-Null
+                Write-Output -InputObject $PSObject
             }
         }
-
-        # Filter the output; Return output to the pipeline
-        $filteredReleases = $releases | Where-Object { $Platform -contains $_.Platform }
-        Write-Output -InputObject $filteredReleases
     }
     Else {
         Write-Warning -Message "$($MyInvocation.MyCommand): failed to return content from $($res.Get.Uri)."

--- a/Evergreen/Public/Get-LibreOffice.ps1
+++ b/Evergreen/Public/Get-LibreOffice.ps1
@@ -4,7 +4,7 @@ Function Get-LibreOffice {
             Gets the latest LibreOffice version and download URIs.
 
         .DESCRIPTION
-            Gets the latest LibreOffice version and download URIs, including help packs / language packs for Windows and macOS.
+            Gets the latest LibreOffice version and download URIs, including help packs / language packs for Windows.
 
         .NOTES
             Author: Bronson Magnan
@@ -17,7 +17,7 @@ Function Get-LibreOffice {
             Get-LibreOffice
 
             Description:
-            Returns the latest LibreOffice version and download URIs for the installers and language packs for Windows and macOS.
+            Returns the latest LibreOffice version and download URIs for the installers and language packs for Windows.
 
         .EXAMPLE
             Get-LibreOffice | Where-Object { ($_.Language -eq "Neutral") -and ($_.Platform -eq "Windows") }
@@ -46,7 +46,6 @@ Function Get-LibreOffice {
         $versions = ($response.Links | Where-Object { $_.href -match $res.Get.MatchVersion }).href -replace "/", ""
         $Version = $versions | Sort-Object -Descending | Select-Object -First 1
     
-        #$Platforms = @("win", "mac")
         ForEach ($platform in $res.Get.Platforms.GetEnumerator()) {
 
             # Get downloads for each platform for the latest version

--- a/Evergreen/Public/Get-MicrosoftFSLogixApps.ps1
+++ b/Evergreen/Public/Get-MicrosoftFSLogixApps.ps1
@@ -36,12 +36,9 @@ Function Get-MicrosoftFSLogixApps {
         # If this returned URL target is a file
         If ($nextRedirectUrl -match $res.Get.MatchFile) {
 
-            # Grab the version number from the link
-            $nextRedirectUrl -match $res.Get.MatchVersion | Out-Null
-
             # Construct the output; Return the custom object to the pipeline
             $PSObject = [PSCustomObject] @{
-                Version = $matches[0]
+                Version = [RegEx]::Match($nextRedirectUrl, $res.Get.MatchVersion).Captures.Value
                 URI     = $nextRedirectUrl
             }
             Write-Output -InputObject $PSObject

--- a/Evergreen/Public/Get-MicrosoftTeams.ps1
+++ b/Evergreen/Public/Get-MicrosoftTeams.ps1
@@ -38,8 +38,7 @@ Function Get-MicrosoftTeams {
         $Json = $Content | ConvertFrom-Json
 
         # Match version number
-        $Json.releasesPath -match $res.Get.MatchVersion | Out-Null
-        $Version = $Matches[1]
+        $Version = [RegEx]::Match($Json.releasesPath, $res.Get.MatchVersion).Captures.Groups[1].Value
 
         # Step through each architecture
         ForEach ($item in $res.Get.DownloadUri.GetEnumerator()) {

--- a/Evergreen/Public/Get-MicrosoftVisualStudioCode.ps1
+++ b/Evergreen/Public/Get-MicrosoftVisualStudioCode.ps1
@@ -4,7 +4,7 @@ Function Get-MicrosoftVisualStudioCode {
             Returns Microsoft Visual Studio Code versions and download URLs.
 
         .DESCRIPTION
-            Reads the Microsoft Visual Studio code update API to retrieve available Stable and Insider builds version numbers and download URLs for Windows, macOS and Linux.
+            Reads the Microsoft Visual Studio code update API to retrieve available Stable and Insider builds version numbers and download URLs for Windows.
 
         .NOTES
             Site: https://stealthpuppy.com
@@ -26,13 +26,13 @@ Function Get-MicrosoftVisualStudioCode {
             Specify the target platform to return Visual Studio Code details for. All supported platforms can be specified.
 
         .EXAMPLE
-            Get-MicrosoftVsCode
+            Get-MicrosoftVisualStudioCode
 
             Description:
             Returns the Stable and Insider builds version numbers and download URLs for Windows, macOS and Linux.
 
         .EXAMPLE
-            Get-MicrosoftVsCode -Channel stable -Platform win32-x64-user
+            Get-MicrosoftVisualStudioCode -Channel stable -Platform win32-x64-user
 
             Description:
             Returns the Stable build version numbers and download URL for the user-install of VSCode for Windows.

--- a/Evergreen/Public/Get-MicrosoftVisualStudioCode.ps1
+++ b/Evergreen/Public/Get-MicrosoftVisualStudioCode.ps1
@@ -29,7 +29,7 @@ Function Get-MicrosoftVisualStudioCode {
             Get-MicrosoftVisualStudioCode
 
             Description:
-            Returns the Stable and Insider builds version numbers and download URLs for Windows, macOS and Linux.
+            Returns the Stable and Insider builds version numbers and download URLs for Windows.
 
         .EXAMPLE
             Get-MicrosoftVisualStudioCode -Channel stable -Platform win32-x64-user

--- a/Evergreen/Public/Get-MicrosoftVisualStudioCode.ps1
+++ b/Evergreen/Public/Get-MicrosoftVisualStudioCode.ps1
@@ -42,15 +42,11 @@ Function Get-MicrosoftVisualStudioCode {
     Param(
         [Parameter()]
         [ValidateSet('insider', 'stable')]
-        [System.String[]] $Channel = @('insider', 'stable'),
+        [System.String[]] $Channel = @('stable'),
 
         [Parameter()]
-        [ValidateSet('darwin', 'win32', 'win32-user', 'win32-x64-user', 'win32-x64', `
-                'win32-archive', 'win32-x64-archive', 'linux-deb-ia32', `
-                'linux-deb-x64', 'linux-rpm-ia32', 'linux-ia32', 'linux-x64')]
-        [System.String[]] $Platform = @('darwin', 'win32', 'win32-user', 'win32-x64-user', 'win32-x64', `
-                'win32-archive', 'win32-x64-archive', 'linux-deb-ia32', `
-                'linux-deb-x64', 'linux-rpm-ia32', 'linux-ia32', 'linux-x64')
+        [ValidateSet('win32', 'win32-user', 'win32-x64-user', 'win32-x64')]
+        [System.String[]] $Platform = @('win32', 'win32-user', 'win32-x64-user', 'win32-x64')
     )
 
     # Get application resource strings from its manifest
@@ -67,10 +63,11 @@ Function Get-MicrosoftVisualStudioCode {
             # Read the version details from the API, format and return to the pipeline
             $releaseJson = Invoke-WebContent -Uri "$($res.Get.Uri)/$plat/$ch/VERSION" | ConvertFrom-Json
             $PSObject = [PSCustomObject] @{
-                Version  = $releaseJson.productVersion
-                Platform = $plat
-                Channel  = $ch
-                URI      = $releaseJson.url
+                Version      = $releaseJson.productVersion
+                Platform     = $plat
+                Architecture = (Get-Architecture -String $releaseJson.url)
+                Channel      = $ch
+                URI          = $releaseJson.url
             }
             Write-Output -InputObject $PSObject
         }

--- a/Evergreen/Public/Get-MicrosoftWvdInfraAgent.ps1
+++ b/Evergreen/Public/Get-MicrosoftWvdInfraAgent.ps1
@@ -1,0 +1,65 @@
+Function Get-MicrosoftWvdInfraAgent {
+    <#
+        .SYNOPSIS
+            Get the current version and download URL for the Microsoft Windows Virtual Desktop Infrastructure agent.
+
+        .NOTES
+            Site: https://stealthpuppy.com
+            Author: Aaron Parker
+            Twitter: @stealthpuppy
+        
+        .LINK
+            https://github.com/aaronparker/Evergreen
+
+        .EXAMPLE
+            Get-MicrosoftWvdInfraAgent
+
+            Description:
+            Returns the current version and download URL for the Microsoft Windows Virtual Desktop Infrastructure agent.
+    #>
+    [OutputType([System.Management.Automation.PSObject])]
+    [CmdletBinding()]
+    Param()
+
+    # Get application resource strings from its manifest
+    $res = Get-FunctionResource -AppName ("$($MyInvocation.MyCommand)".Split("-"))[1]
+    Write-Verbose -Message $res.Name
+
+    # Grab the download link headers to find the file name
+    try {
+        $params = @{
+            Uri             = $res.Get.Uri
+            Method          = "Head"
+            UseBasicParsing = $True
+            ErrorAction     = $script:resourceStrings.Preferences.ErrorAction
+        }
+        $Content = (Invoke-WebRequest @params).RawContent
+    }
+    catch [System.Net.WebException] {
+        Write-Warning -Message "$($MyInvocation.MyCommand): Error at: $Uri."
+        Throw ([string]::Format("Error : {0}", $_.Exception.StatusCode))
+    }
+    catch {
+        Write-Warning -Message "$($MyInvocation.MyCommand): Error at: $Uri."
+        Throw ([string]::Format("Error : {0}", $_.Exception.StatusCode))
+    }
+
+    # Check content was returned
+    If ($Content) {
+
+        # Match filename
+        $Filename = [RegEx]::Match($Content, $res.Get.MatchFilename).Captures.Groups[1].Value
+
+        # Construct the output; Return the custom object to the pipeline
+        $PSObject = [PSCustomObject] @{
+            Version      = [RegEx]::Match($Content, $res.Get.MatchVersion).Captures.Value
+            Architecture = Get-Architecture -String $Filename
+            Filename     = $Filename
+            URI          = $res.Get.Uri
+        }
+        Write-Output -InputObject $PSObject
+    }
+    Else {
+        Write-Warning -Message "$($MyInvocation.MyCommand): Failed to return a header from $($res.Get.Uri)."
+    }
+}

--- a/Evergreen/Public/Get-MozillaFirefox.ps1
+++ b/Evergreen/Public/Get-MozillaFirefox.ps1
@@ -27,17 +27,17 @@ Function Get-MozillaFirefox {
             Returns the 64-bit English (US) download URI for Firefox for Windows.
 
         .EXAMPLE
-            Get-MozillaFirefoxUri -Language en-GB -Platform mac
+            Get-MozillaFirefoxUri -Language en-GB
 
             Description:
-            Returns the UK English download URI for Firefox for macOS.
+            Returns the UK English download URI for Firefox.
     #>
     [OutputType([System.Management.Automation.PSObject])]
     [CmdletBinding()]
     Param(
         [Parameter(Position = 0)]
-        [ValidateSet('win64', 'win32', 'mac', 'linux-x86_64', 'linux-i686')]
-        [System.String[]] $Platform = @('win64', 'win32', 'mac', 'linux-x86_64', 'linux-i686'),
+        [ValidateSet('win64', 'win32')]
+        [System.String[]] $Platform = @('win64', 'win32'),
 
         [Parameter(Position = 1)]
         [ValidateSet('en-US', 'en-GB', 'en-CA', 'en-ZA', 'es-ES', 'es-AR', 'es-CL', 'es-MX', 'sv-SE', 'pt-BR', 'pt-PT', `
@@ -67,18 +67,15 @@ Function Get-MozillaFirefox {
             Switch ($plat) {
                 "win64" { $file = "Firefox%20Setup%20$($version).exe" }
                 "win32" { $file = "Firefox%20Setup%20$($version).exe" }
-                "mac" { $file = "Firefox%20$($version).dmg" }
-                "linux-x86_64" { $file = "firefox-$($version).tar.bz2" }
-                "linux-i686" { $file = "firefox-$($version).tar.bz2" }
             }
 
             # Build object and output to the pipeline
             $PSObject = [PSCustomObject] @{
-                Version  = $version
-                Platform = $plat
-                Language = $lang
-                Filename = $file.Replace('%20', ' ')
-                URI      = "$($res.Get.DownloadUri)$($version)/$($plat)/$($lang)/$($file)"
+                Version      = $version
+                Architecture = Get-Architecture -String $plat
+                Language     = $lang
+                Filename     = $file.Replace('%20', ' ')
+                URI          = "$($res.Get.DownloadUri)$($version)/$($plat)/$($lang)/$($file)"
             }
             Write-Output -InputObject $PSObject
         }

--- a/Evergreen/Public/Get-NotepadPlusPlus.ps1
+++ b/Evergreen/Public/Get-NotepadPlusPlus.ps1
@@ -63,13 +63,9 @@
                     Default { $platform = "Windows" }
                 }
 
-                # Match version number
-                $latestRelease.tag_name -match $res.Get.MatchVersion | Out-Null
-                $Version = $Matches[0]
-
                 # Build and array of the latest release and download URLs
                 $PSObject = [PSCustomObject] @{
-                    Version      = $Version
+                    Version      = [RegEx]::Match($latestRelease.tag_name, $res.Get.MatchVersion).Captures.Groups[1].Value
                     Platform     = $platform
                     Architecture = $arch
                     Date         = (ConvertTo-DateTime -DateTime $release.created_at)

--- a/Evergreen/Public/Get-OracleVirtualBox.ps1
+++ b/Evergreen/Public/Get-OracleVirtualBox.ps1
@@ -52,25 +52,7 @@ Function Get-OracleVirtualBox {
                 $link -match $res.Get.MatchDownloadFile | Out-Null
                 $PSObject = [PSCustomObject] @{
                     Version  = $Version
-                    Platform = "Platform"
                     URI      = "$($res.Get.DownloadUri)$Version/$($Matches[1])"
-                }
-                Switch ($PSObject.URI.Substring($PSObject.URI.Length - 3)) {
-                    "exe" {
-                        $PSObject.Platform = "Windows"
-                    }
-                    "dmg" {
-                        $PSObject.Platform = "macOS"
-                    }
-                    "deb" {
-                        $PSObject.Platform = "Debian"
-                    }
-                    "rpm" {
-                        $PSObject.Platform = "RedHat"
-                    }
-                    Default {
-                        $PSObject.Platform = "Unknown"
-                    }
                 }
                 Write-Output -InputObject $PSObject
             }

--- a/Evergreen/Public/Get-OracleVirtualBox.ps1
+++ b/Evergreen/Public/Get-OracleVirtualBox.ps1
@@ -28,8 +28,7 @@ Function Get-OracleVirtualBox {
     $Version = Invoke-WebContent -Uri $res.Get.Uri
 
     If ($Null -ne $Version) {
-        $Version -match $res.Get.MatchVersion | Out-Null
-        $Version = $Matches[0]
+        $Version = [RegEx]::Match($Version, $res.Get.MatchVersion).Captures.Groups[1].Value
         Write-Verbose "$($res.Get.DownloadUri)$Version/"
     
         # Get the content from the latest downloads folder
@@ -51,8 +50,8 @@ Function Get-OracleVirtualBox {
             ForEach ($link in $Links) {
                 $link -match $res.Get.MatchDownloadFile | Out-Null
                 $PSObject = [PSCustomObject] @{
-                    Version  = $Version
-                    URI      = "$($res.Get.DownloadUri)$Version/$($Matches[1])"
+                    Version = $Version
+                    URI     = "$($res.Get.DownloadUri)$Version/$($Matches[1])"
                 }
                 Write-Output -InputObject $PSObject
             }

--- a/Evergreen/Public/Get-PaintDotNet.ps1
+++ b/Evergreen/Public/Get-PaintDotNet.ps1
@@ -14,24 +14,18 @@ Function Get-PaintDotNet {
 
     # Read the Paint.NET updates feed
     $Content = Invoke-WebContent -Uri $res.Get.Uri
-
     If ($Null -ne $Content) {
-        # Match version and download strings from the content
-        $Content -match $res.Get.MatchVersion | Out-Null
-        $Version = $Matches[1].Trim()
-    
+
+        # Convert the content from string data
+        $Data = $Content | ConvertFrom-StringData
+
         # Build the output object
-        If ($Version) {
-            $Content -match ($res.Get.MatchDownload -replace "#Version", ($Version -replace "\.", "\.")) | Out-Null
-            $Download = $Matches[1].Split(",")[0]
+        ForEach ($url in ($Data.("$($Data.StableVersions)$($res.Get.UrlProperty)") -split $res.Get.UrlDelimiter)) {
             $PSObject = [PSCustomObject] @{
-                Version = $Version
-                URI     = $Download
+                Version = $Data.($res.Get.VersionProperty)
+                URI     = $url
             }
             Write-Output -InputObject $PSObject
-        }
-        Else {
-            Write-Warning -Message "Failed to find version number from feed."
         }
     }
 }

--- a/Evergreen/Public/Get-ScooterBeyondCompare.ps1
+++ b/Evergreen/Public/Get-ScooterBeyondCompare.ps1
@@ -53,12 +53,9 @@
                 $nodes = Select-Xml -Xml $xmlDocument -XPath $res.Get.XmlNode | Select-Object –ExpandProperty "node"
                 ForEach ($node in $nodes) {
 
-                    # Extract version number
-                    $node.latestversion -match $res.Get.MatchVersion | Out-Null
-
                     # Build an array of the latest release and download URLs
                     $PSObject = [PSCustomObject] @{
-                        Version  = $matches[0]
+                        Version  = [RegEx]::Match($node.latestversion, $res.Get.MatchVersion).Captures.Value
                         Language = $res.Get.Languages[$language.key]
                         URI      = $node.download
                     }

--- a/Evergreen/Public/Get-TeamViewer.ps1
+++ b/Evergreen/Public/Get-TeamViewer.ps1
@@ -15,7 +15,7 @@ Function Get-TeamViewer {
             Get-TeamViewer
 
             Description:
-            Returns the current version and download URI for TeamViewer on Windows (x86, x64) and macOS.
+            Returns the current version and download URI for TeamViewer on Windows.
     #>
     [OutputType([System.Management.Automation.PSObject])]
     [CmdletBinding()]

--- a/Evergreen/Public/Get-VideoLanVlcPlayer.ps1
+++ b/Evergreen/Public/Get-VideoLanVlcPlayer.ps1
@@ -15,7 +15,7 @@
             Get-VideoLanVlcPlayer
 
             Description:
-            Returns the current version and download URLs for VLC Media Player on Windows (x86, x64) and macOS.
+            Returns the current version and download URLs for VLC Media Player on Windows.
     #>
     [OutputType([System.Management.Automation.PSObject])]
     [CmdletBinding()]
@@ -24,51 +24,6 @@
     # Get application resource strings from its manifest
     $res = Get-FunctionResource -AppName ("$($MyInvocation.MyCommand)".Split("-"))[1]
     Write-Verbose -Message $res.Name
-
-    #region Get current version for macOS
-    $Content = Invoke-WebContent -Uri $res.Get.Uri.macOS
-
-    If ($Null -ne $Content) {
-
-        Try {
-            [System.XML.XMLDocument] $xmlDocument = $Content
-        }
-        Catch [System.Exception] {
-            Write-Warning -Message "$($MyInvocation.MyCommand): failed to convert feed into an XML object."
-            Break
-        }
-
-        # Build an output object by selecting installer entries from the feed
-        If ($xmlDocument -is [System.XML.XMLDocument]) {
-
-            # Select the required node/s from the XML feed
-            $nodes = Select-Xml -Xml $xmlDocument -XPath $res.Get.XmlNode | Select-Object –ExpandProperty "node"
-
-            # Find the latest version
-            $latest = $nodes | Sort-Object -Property "title" -Descending | Select-Object -First 1
-            $version = $latest.title.Trim($res.Get.TrimVersion)
-
-            # Follow the download link which will return a 301
-            $rruParams = @{
-                Uri       = $($res.Get.DownloadUriMacOS -replace "#version", $version)
-                UserAgent = $res.Get.UserAgent
-            }
-            $redirectUrl = Resolve-RedirectedUri @rruParams
-
-            # Construct the output; Return the custom object to the pipeline
-            ForEach ($extension in $res.Get.Extensions.macOS) {
-                $PSObject = [PSCustomObject] @{
-                    Version      = $version
-                    Platform     = "macOS"
-                    Architecture = "x64"
-                    Type         = $extension
-                    URI          = $redirectUrl
-                }
-                Write-Output -InputObject $PSObject
-            }
-        }
-    }
-    #endregion
 
     #region Get current version for Windows
     ForEach ($platform in $res.Get.Uri.Windows.GetEnumerator()) {

--- a/Evergreen/Public/Get-dnGrep.ps1
+++ b/Evergreen/Public/Get-dnGrep.ps1
@@ -1,0 +1,40 @@
+Function Get-dnGrep {
+    <#
+        .SYNOPSIS
+            Returns the available dnGrep versions and downloads.
+
+        .DESCRIPTION
+            Returns the available dnGrep versions and downloads.
+
+        .NOTES
+            Author: Aaron Parker
+            Twitter: @stealthpuppy
+        
+        .LINK
+            https://github.com/aaronparker/Evergreen
+
+        .EXAMPLE
+            Get-dnGrep
+
+            Description:
+            Returns the released Base Image Script Framework version and download URI.
+    #>
+    [OutputType([System.Management.Automation.PSObject])]
+    [CmdletBinding()]
+    Param()
+
+    # Get application resource strings from its manifest
+    $res = Get-FunctionResource -AppName ("$($MyInvocation.MyCommand)".Split("-"))[1]
+    Write-Verbose -Message $res.Name
+
+    # Get latest version and download latest release via GitHub API
+    $iwcParams = @{
+        Uri         = $res.Get.Uri
+        ContentType = $res.Get.ContentType
+    }
+    $Content = Invoke-WebContent @iwcParams
+
+    # Convert the returned release data into a useable object with Version, URI etc.
+    $object = ConvertFrom-GitHubReleasesJson -Content $Content -MatchVersion $res.Get.MatchVersion
+    Write-Output -InputObject $object
+}

--- a/tests/PrivateFunctions.Tests.ps1
+++ b/tests/PrivateFunctions.Tests.ps1
@@ -18,6 +18,7 @@ Else {
 }
 $moduleParent = Join-Path -Path $projectRoot -ChildPath $module
 $manifestPath = Join-Path -Path $moduleParent -ChildPath "$module.psd1"
+$ProgressPreference = [System.Management.Automation.ActionPreference]::SilentlyContinue
 
 # Import module
 Write-Host ""

--- a/tests/PublicFunctions.Tests.ps1
+++ b/tests/PublicFunctions.Tests.ps1
@@ -18,6 +18,7 @@ Else {
 }
 $moduleParent = Join-Path -Path $projectRoot -ChildPath $module
 $manifestPath = Join-Path -Path $moduleParent -ChildPath "$module.psd1"
+$ProgressPreference = [System.Management.Automation.ActionPreference]::SilentlyContinue
 
 # Import module
 Write-Host ""
@@ -26,17 +27,19 @@ Import-Module $manifestPath -Force
 
 # Create download path
 $Path = Join-Path -Path $env:Temp -ChildPath "Downloads"
-New-Item -Path $Path -ItemType Directory -Force -ErrorAction SilentlyContinue
+New-Item -Path $Path -ItemType Directory -Force -ErrorAction "SilentlyContinue"
 
 # RegEx
 $matchUrl = "(\s*\[+?\s*(\!?)\s*([a-z]*)\s*\|?\s*([a-z0-9\.\-_]*)\s*\]+?)?\s*([^\s]+)\s*"
 
-Describe -Tag "AppVeyor" -Name "Test" {
+# Get the module commands
+$commands = Get-Command -Module Evergreen
 
-    $commands = Get-Command -Module Evergreen
+Describe -Tag "General" -Name "Properties" {
     ForEach ($command in $commands) {
 
-        Context "Validate $($command.Name)" {
+        Context "Validate $($command.Name) properties" {
+
             # Run each command and capture output in a variable
             New-Variable -Name "tempOutput" -Value (. $command.Name )
             $Output = (Get-Variable -Name "tempOutput").Value
@@ -73,10 +76,32 @@ Describe -Tag "AppVeyor" -Name "Test" {
                     It "$($command.Name): URI is a valid URL" {
                         $object.URI | Should -Match $matchUrl
                     }
+                }
+            }
+            Else {
+                Write-Host -ForegroundColor "Yellow" "`t$($command.Name) does not have a URI property."
+            }
+        }
+    }
+}
+
+Describe -Tag "Download" -Name "Downloads" {
+    ForEach ($command in $commands) {
+
+        Context "Validate $($command.Name) downloads" {
+            # Run each command and capture output in a variable
+            New-Variable -Name "tempOutput" -Value (. $command.Name )
+            $Output = (Get-Variable -Name "tempOutput").Value
+            Remove-Variable -Name tempOutput
+            
+            # Test that the functions that have a URI property return something we can download
+            # If URI is 'Unknown' there's probably a problem with the source
+            If ([bool]($Output[0].PSobject.Properties.name -match "URI")) {
+                ForEach ($object in $Output) {
                     It "$($command.Name): [$(Split-Path -Path $object.URI -Leaf)] is a valid download target" {
                         try {
                             # Test URI exists without downloading the file
-                            $r = Invoke-WebRequest -Uri $object.URI -Method Head -UseBasicParsing -ErrorAction SilentlyContinue
+                            $r = Invoke-WebRequest -Uri $object.URI -Method "Head" -UseBasicParsing -ErrorAction "SilentlyContinue"
                         }
                         catch {
                             # If Method Head fails, try downloading the URI
@@ -84,7 +109,7 @@ Describe -Tag "AppVeyor" -Name "Test" {
                             $OutFile = Join-Path -Path $Path (Split-Path -Path $object.URI -Leaf)
                             try {
                                 $r = Invoke-WebRequest -Uri $object.URI -OutFile $OutFile -UseBasicParsing -PassThru `
-                                    -ErrorAction SilentlyContinue
+                                    -ErrorAction "SilentlyContinue"
                             }
                             catch {
                                 # If all else fails, let's pretend the URI is OK. Some URIs may require a login etc.
@@ -106,3 +131,4 @@ Describe -Tag "AppVeyor" -Name "Test" {
         }
     }
 }
+Write-Host ""


### PR DESCRIPTION
* Adds `Get-MicrosoftWvdInfraAgent`
* Adds `Get-dnGrep`
* Recode of `Get-PaintDotNet` (or how did I not know about `ConvertFrom-StringData` before?)
* To simplify output, removes Linux, macOS output from `Get-CitrixWorkspaceApp`, `Get-GoogleChrome`, `Get-OracleVirtuaBox`, `Get-LibreOffice`, `Get-MicrosoftVisualStudioCode`, `Get-MozillaFirefox`, `Get-OracleVirtualBox`, `Get-TeamViewer`
* Updates RegEx method to extract version across various functions to simplify code
* Splits Pester tests for Public functions to allow for faster local testing