### PR TITLE
Last minute fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## VERSION
+
+* Fixes an issue where `Get-MicrosoftEdge` was only returning ARM64 downloads
+* Updates `Get-MicrosoftEdge` to only return downloads for the Enterprise ring (removed Consumer ring)
+* Fixes an issue with `Get-MicrosoftTeams` where is was returning an incorrect download URL
+
 ## 2005.172
 
 * Updates `Get-MicrosoftEdge` to correctly return the latest version and policy files for the Enterprise ring

--- a/Evergreen/Manifests/MicrosoftEdge.json
+++ b/Evergreen/Manifests/MicrosoftEdge.json
@@ -4,8 +4,7 @@
 	"Get": {
 		"Uri": "https://edgeupdates.microsoft.com/api/products",
 		"Views": {
-			"Enterprise": "?view=enterprise",
-			"Consumer": ""
+			"Enterprise": "?view=enterprise"
 		},
 		"Platform": [
 			"Windows",
@@ -16,6 +15,12 @@
 			"Beta",
 			"EdgeUpdate",
 			"Policy"
+		],
+		"Architectures": [
+			"x64",
+			"x86",
+			"arm64",
+			"any"
 		],
 		"ReleaseProperty": "Releases",
 		"SortProperty": "ProductVersion",

--- a/Evergreen/Public/Get-MicrosoftEdge.ps1
+++ b/Evergreen/Public/Get-MicrosoftEdge.ps1
@@ -51,12 +51,18 @@ Function Get-MicrosoftEdge {
             # For each product (Stable, Beta etc.)
             ForEach ($product in $res.Get.Channels) {
 
-                # Expand the Releases property for that product
-                $releases = $EdgeReleases | Where-Object { $_.Product -eq $product } | `
+                # Find the latest version
+                $latestRelease = $EdgeReleases | Where-Object { $_.Product -eq $product } | `
                     Select-Object -ExpandProperty $res.Get.ReleaseProperty | `
                     Where-Object { $_.Platform -in $res.Get.Platform } | `
                     Sort-Object -Property $res.Get.SortProperty -Descending | `
                     Select-Object -First 1
+                Write-Verbose -Message "$($MyInvocation.MyCommand): Found version: $($latestRelease.ProductVersion)."
+
+                # Expand the Releases property for that product version
+                $releases = $EdgeReleases | Where-Object { $_.Product -eq $product } | `
+                    Select-Object -ExpandProperty $res.Get.ReleaseProperty | `
+                    Where-Object { ($_.Platform -in $res.Get.Platform) -and ($_.ProductVersion -eq $latestRelease.ProductVersion) }
                 Write-Verbose -Message "$($MyInvocation.MyCommand): Found $($releases.count) objects for: $product, with $($releases.Artifacts.count) artifacts."
 
                 ForEach ($release in $releases) {

--- a/Evergreen/Public/Get-MicrosoftTeams.ps1
+++ b/Evergreen/Public/Get-MicrosoftTeams.ps1
@@ -47,7 +47,7 @@ Function Get-MicrosoftTeams {
             $PSObject = [PSCustomObject] @{
                 Version      = $Version
                 Architecture = $item.Name
-                URI          = $res.Get.DownloadUri[$item.Key] -replace $reg.Get.DownloadUriReplaceText, $Version
+                URI          = $res.Get.DownloadUri[$item.Key] -replace $res.Get.DownloadUriReplaceText, $Version
             }
 
             # Output object to the pipeline

--- a/Evergreen/Public/Get-VMwareTools.ps1
+++ b/Evergreen/Public/Get-VMwareTools.ps1
@@ -38,7 +38,7 @@
         $VersionTable = $Lines | ConvertFrom-Csv -Delimiter "," -Header $res.Get.CsvHeaders | Sort-Object -Property {[Version] $_.Version} -Descending
 
         # Match the latest version number
-        If ($VersionTable[0].Server -match $reg.Get.MatchNoServer) {
+        If ($VersionTable[0].Server -match $res.Get.MatchNoServer) {
             $Version = ($VersionTable | Select-Object -First 2 | Select-Object -Last 1).Version
         }
         Else {


### PR DESCRIPTION
* Fixes an issue where `Get-MicrosoftEdge` was only returning ARM64 downloads
* Updates `Get-MicrosoftEdge` to only return downloads for the Enterprise ring (removed Consumer ring)
* Fixes an issue with `Get-MicrosoftTeams` where it is was returning an incorrect download URL