### PR TITLE
Development

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## VERSION
 
+* Fix path in downloads from apps hosted on Source Forge returned in `ConvertFrom-SourceForgeReleasesJson.ps1`. Fixes #67
+* Update `Get-MozillaFirefox` to return Extended Support Release as well as Current Release. Address #61
+* Update manifests to address #57 #54 #53 #52
+
+## 2006.203
+
 * Removes Size property from `Get-FoxitReader` because this isn't being gathered consistently for each download
 * Updates version / releases feed for `Get-MicrosftSsms` to ensure the current version is returned
 * Updates the way private function `ConvertFrom-SourceForgeReleasesJson` returns available downloads from SourceForge

--- a/Evergreen/Manifests/7zip.json
+++ b/Evergreen/Manifests/7zip.json
@@ -7,7 +7,8 @@
 			"ContentType": "application/json; charset=utf-8"
 		},
 		"Download" : {
-			"Feed": "https://sourceforge.net/projects/sevenzip/rss?path=/7-Zip",
+			"Folder": "7-Zip",
+			"Feed": "https://sourceforge.net/projects/sevenzip/rss?path=",
 			"XPath": "//item",
 			"FilterProperty": "link",
 			"ContentType": "application/rss+xml; charset=utf-8",

--- a/Evergreen/Manifests/7zip.json
+++ b/Evergreen/Manifests/7zip.json
@@ -18,13 +18,13 @@
 		"DatePattern": "yyyy-MM-dd HH:mm:ss"
 	},
 	"Install": {
-		"Setup": "WinMerge*.exe",
+		"Setup": "7z*.exe|7z.msi",
 		"Physical": {
-			"Arguments": "/Silent",
+			"Arguments": "",
 			"PostInstall": []
 		},
 		"Virtual": {
-			"Arguments": "/Silent",
+			"Arguments": "",
 			"PostInstall": []
 		}
 	}

--- a/Evergreen/Manifests/KeePass.json
+++ b/Evergreen/Manifests/KeePass.json
@@ -7,7 +7,8 @@
 			"ContentType": "application/json; charset=utf-8"
 		},
 		"Download" : {
-			"Feed": "https://sourceforge.net/projects/keepass/rss?path=/KeePass%202.x",
+			"Folder": "KeePass%202.x",
+			"Feed": "https://sourceforge.net/projects/keepass/rss?path=",
 			"XPath": "//item",
 			"FilterProperty": "link",
 			"ContentType": "application/rss+xml; charset=utf-8",

--- a/Evergreen/Manifests/MicrosoftEdge.json
+++ b/Evergreen/Manifests/MicrosoftEdge.json
@@ -29,17 +29,17 @@
 		"FileTypes": "\\.exe$|\\.msi$|\\.msp$|\\.zip$"
 	},
 	"Install": {
-		"Setup": "",
+		"Setup": "MicrosoftEdge*.msi",
 		"Physical": {
-			"Arguments": "DONOTCREATEDESKTOPSHORTCUT=TRUE",
+			"Arguments": "/passive /norestart DONOTCREATEDESKTOPSHORTCUT=TRUE",
 			"PostInstall": [
-				"Remove-Item -Path \"$env:Public\\Destkop\\Microsoft Edge.lnk\" -Force"
+				"Remove-Item -Path \"$env:Public\\Desktop\\Microsoft Edge.lnk\" -Force -ErrorAction SilentlyContinue"
 			]
 		},
 		"Virtual": {
-			"Arguments": "DONOTCREATEDESKTOPSHORTCUT=TRUE",
+			"Arguments": "/passive /norestart DONOTCREATEDESKTOPSHORTCUT=TRUE",
 			"PostInstall": [
-				"Remove-Item -Path \"$env:Public\\Destkop\\Microsoft Edge.lnk\" -Force"
+				"Remove-Item -Path \"$env:Public\\Desktop\\Microsoft Edge.lnk\" -Force -ErrorAction SilentlyContinue"
 			]
 		}
 	}

--- a/Evergreen/Manifests/MicrosoftTeams.json
+++ b/Evergreen/Manifests/MicrosoftTeams.json
@@ -12,17 +12,17 @@
 		"DownloadUriReplaceText": "#Version"
 	},
 	"Install": {
-		"Setup": "",
+		"Setup": "Teams*.msi",
 		"Physical": {
 			"Arguments": "",
 			"PostInstall": [
-				"Remove-Item -Path \"$env:Public\\Destkop\\Microsoft Teams.lnk\" -Force -ErrorAction SilentlyContinue"
+				"Remove-Item -Path \"$env:Public\\Desktop\\Microsoft Teams.lnk\" -Force -ErrorAction SilentlyContinue"
 			]
 		},
 		"Virtual": {
 			"Arguments": "ALLUSER=1 ALLUSERS=1",
 			"PostInstall": [
-				"Remove-Item -Path \"$env:Public\\Destkop\\Microsoft Teams.lnk\" -Force -ErrorAction SilentlyContinue"
+				"Remove-Item -Path \"$env:Public\\Desktop\\Microsoft Teams.lnk\" -Force -ErrorAction SilentlyContinue"
 			]
 		}
 	}

--- a/Evergreen/Manifests/MozillaFirefox.json
+++ b/Evergreen/Manifests/MozillaFirefox.json
@@ -2,7 +2,13 @@
 	"Name": "Mozilla Firefox",
 	"Source": "https://www.mozilla.org/",
 	"Get": {
-		"Uri": "https://product-details.mozilla.org/1.0/firefox_versions.json",
+		"Update": {
+			"Uri": "https://product-details.mozilla.org/1.0/firefox_versions.json",
+			"Channels": [
+				"FIREFOX_ESR",
+				"LATEST_FIREFOX_VERSION"
+			]
+		},
 		"DownloadUri": "https://download-installer.cdn.mozilla.net/pub/firefox/releases/"
 	},
 	"Install": {
@@ -10,11 +16,14 @@
 		"Physical": {
 			"Arguments": "/S /TaskbarShortcut=false /DesktopShortcut=false /MaintenanceService=true /PreventRebootRequired=true",
 			"PostInstall": [
+
 			]
 		},
 		"Virtual": {
 			"Arguments": "/S /TaskbarShortcut=false /DesktopShortcut=false /MaintenanceService=false /PreventRebootRequired=true",
-			"PostInstall": []
+			"PostInstall": [
+
+			]
 		}
 	}
 }

--- a/Evergreen/Manifests/PDFForgePDFCreator.json
+++ b/Evergreen/Manifests/PDFForgePDFCreator.json
@@ -7,7 +7,8 @@
 			"ContentType": "application/json; charset=utf-8"
 		},
 		"Download" : {
-			"Feed": "https://sourceforge.net/projects/pdfcreator/rss?path=/PDFCreator",
+			"Folder": "PDFCreator",
+			"Feed": "https://sourceforge.net/projects/pdfcreator/rss?path=",
 			"XPath": "//item",
 			"FilterProperty": "link",
 			"ContentType": "application/rss+xml; charset=utf-8",

--- a/Evergreen/Manifests/WinMerge.json
+++ b/Evergreen/Manifests/WinMerge.json
@@ -7,7 +7,8 @@
 			"ContentType": "application/json; charset=utf-8"
 		},
 		"Download" : {
-			"Feed": "https://sourceforge.net/projects/winmerge/rss?path=/stable",
+			"Folder": "stable",
+			"Feed": "https://sourceforge.net/projects/winmerge/rss?path=",
 			"XPath": "//item",
 			"FilterProperty": "link",
 			"ContentType": "application/rss+xml; charset=utf-8",

--- a/Evergreen/Manifests/WinSCP.json
+++ b/Evergreen/Manifests/WinSCP.json
@@ -7,7 +7,8 @@
 			"ContentType": "application/json; charset=utf-8"
 		},
 		"Download" : {
-			"Feed": "https://sourceforge.net/projects/winscp/rss?path=/WinSCP",
+			"Folder": "WinSCP",
+			"Feed": "https://sourceforge.net/projects/winscp/rss?path=",
 			"XPath": "//item",
 			"FilterProperty": "link",
 			"ContentType": "application/rss+xml; charset=utf-8",

--- a/Evergreen/Private/ConvertFrom-SourceForgeReleasesJson.ps1
+++ b/Evergreen/Private/ConvertFrom-SourceForgeReleasesJson.ps1
@@ -62,7 +62,7 @@
 
     # Get the downloads XML feed
     $iwcParams = @{
-        Uri         = $Download.Feed
+        Uri         = "$($Download.Feed)/$($Download.Folder)"
         ContentType = $Download.ContentType
         Raw         = $True
     }
@@ -92,7 +92,7 @@
             $PSObject = [PSCustomObject] @{
                 Version      = $Version
                 Architecture = Get-Architecture -String $File
-                URI          = "$($Download.Uri)/$Version/$File" -replace " ", "%20"
+                URI          = "$($Download.Uri)/$($Download.Folder)/$Version/$File" -replace " ", "%20"
             }
             Write-Output -InputObject $PSObject
         }

--- a/Evergreen/Public/Get-MozillaFirefox.ps1
+++ b/Evergreen/Public/Get-MozillaFirefox.ps1
@@ -56,27 +56,29 @@ Function Get-MozillaFirefox {
     Write-Verbose -Message $res.Name
 
     # Get latest Firefox version
-    $firefoxVersions = Invoke-WebContent -Uri $res.Get.Uri | ConvertFrom-Json
+    $firefoxVersions = Invoke-WebContent -Uri $res.Get.Update.Uri | ConvertFrom-Json
     
     # Construct custom object with output details
     ForEach ($lang in $Language) {
         ForEach ($plat in $Platform) {
+            ForEach ($channel in $res.Get.Update.Channels) {
 
-            # Select the download file for the selected platform
-            Switch ($plat) {
-                "win64" { $file = "Firefox%20Setup%20$($firefoxVersions.LATEST_FIREFOX_VERSION).exe" }
-                "win32" { $file = "Firefox%20Setup%20$($firefoxVersions.LATEST_FIREFOX_VERSION).exe" }
-            }
+                # Select the download file for the selected platform
+                Switch ($plat) {
+                    "win64" { $file = "Firefox%20Setup%20$($firefoxVersions.$channel).exe" }
+                    "win32" { $file = "Firefox%20Setup%20$($firefoxVersions.$channel).exe" }
+                }
 
-            # Build object and output to the pipeline
-            $PSObject = [PSCustomObject] @{
-                Version      = $firefoxVersions.LATEST_FIREFOX_VERSION
-                Architecture = Get-Architecture -String $plat
-                Language     = $lang
-                Filename     = $file.Replace('%20', ' ')
-                URI          = "$($res.Get.DownloadUri)$($firefoxVersions.LATEST_FIREFOX_VERSION)/$($plat)/$($lang)/$($file)"
+                # Build object and output to the pipeline
+                $PSObject = [PSCustomObject] @{
+                    Version      = $firefoxVersions.$channel
+                    Architecture = Get-Architecture -String $plat
+                    Language     = $lang
+                    Filename     = $file.Replace('%20', ' ')
+                    URI          = "$($res.Get.DownloadUri)$($firefoxVersions.$channel)/$($plat)/$($lang)/$($file)"
+                }
+                Write-Output -InputObject $PSObject
             }
-            Write-Output -InputObject $PSObject
         }
     }
 }


### PR DESCRIPTION
* Fix path in downloads from apps hosted on Source Forge returned in `ConvertFrom-SourceForgeReleasesJson.ps1`. Fixes #67
* Update `Get-MozillaFirefox` to return Extended Support Release as well as Current Release. Address. Fixes #61
* Update manifests to address. Fixes #57 #54 #53 #52