### PR TITLE
Fix values in Get-AdobeAcrobat

### DIFF
--- a/Evergreen/Public/Get-AdobeAcrobat.ps1
+++ b/Evergreen/Public/Get-AdobeAcrobat.ps1
@@ -47,7 +47,8 @@ Function Get-AdobeAcrobat {
                         Version  = $Content
                         Type     = $res.Get.Download.Type
                         Product  = $Product.Name
-                        Track    = $Url.Name
+                        Track    = $item.Name
+                        Language = $Url.Name
                         URI      = ($res.Get.Download.Uri.($Product.Name)[$Url.key] -replace $res.Get.Download.ReplaceText.Version, $versionString) -replace $res.Get.Download.ReplaceText.Track, $item.Name
                     }
                     Write-Output -InputObject $PSObject

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,10 @@ toc: false
 permalink: changelog.html
 summary: Changes, updates, fixes and breaking changes in each Evergreen version.
 ---
+## VERSION
+
+* Fixes an issue with `Get-AdobeAcrobat` to ensure that `Track` property has the correct value (DC, 2020, etc.) and the `Language` property (Neutral, Multi) [#130](https://github.com/aaronparker/Evergreen/issues/130)
+
 ## 2103.303
 
 * Adds `Get-NETworkManager`, `Get-Anki`


### PR DESCRIPTION
* Fixes an issue with `Get-AdobeAcrobat` to ensure that `Track` property has the correct value (DC, 2020, etc.) and the `Language` property (Neutral, Multi). Addresses #130 