### PR TITLE
Development

### DIFF
--- a/Evergreen/Apps/Get-CitrixWorkspaceApp.ps1
+++ b/Evergreen/Apps/Get-CitrixWorkspaceApp.ps1
@@ -55,6 +55,6 @@
                 }
             }
         }
-        Write-Warning -Message "$($MyInvocation.MyCommand): HDX RTME for Windows version returned is out of date. Use 'CitrixWorkspaceAppFeed' to find the latest HDX RTME version."
+        Write-Warning -Message "$($MyInvocation.MyCommand): HDX RTME for Windows version returned is out of date. See https://stealthpuppy.com/Evergreen/changelog.html for more information."
     }
 }

--- a/Evergreen/Apps/Get-FoxitReader.ps1
+++ b/Evergreen/Apps/Get-FoxitReader.ps1
@@ -22,25 +22,24 @@ Function Get-FoxitReader {
     )
 
     # Query the Foxit Reader package download form to get the JSON
-    $updateFeed = Invoke-RestMethodWrapper -Uri $res.Get.Uri
+    $updateFeed = Invoke-RestMethodWrapper -Uri $res.Get.Update.Uri
     If ($Null -ne $updateFeed) {
 
         # Grab latest version
         $Version = ($updateFeed.package_info.version | Sort-Object { [Version]$_ } -Descending) | Select-Object -First 1
 
-        ForEach ($language in $updateFeed.package_info.language) {
+        # Build the output object for each language. Excludes languages with out-of-date versions
+        ForEach ($language in ($updateFeed.package_info.language | Where-Object { $_ -notin $res.Get.Update.SkipLanguages })) {
             
-            # Build the download URL
-            $Uri = (($res.Get.DownloadUri -replace "#Version", $Version) -replace "#Language", $language) -replace "#Package", $updateFeed.package_info.type[0]
-            
-            # Follow the download link which will return a 301/302
+            # Build the download URL; Follow the download link which will return a 301/302
+            $Uri = (($res.Get.Download.Uri -replace "#Version", $Version) -replace "#Language", $language) -replace "#Package", $updateFeed.package_info.type[0]
             $redirectUrl = Resolve-InvokeWebRequest -Uri $Uri
             
             # Construct the output; Return the custom object to the pipeline
             If ($Null -ne $redirectUrl) {
                 $PSObject = [PSCustomObject] @{
                     Version  = $Version
-                    Date     = ConvertTo-DateTime -DateTime $updateFeed.package_info.release -Pattern $res.Get.DateTimePattern
+                    Date     = ConvertTo-DateTime -DateTime $updateFeed.package_info.release -Pattern $res.Get.Update.DateTimePattern
                     Language = $language
                     URI      = $redirectUrl
                 }

--- a/Evergreen/Apps/Get-MicrosoftSsms.ps1
+++ b/Evergreen/Apps/Get-MicrosoftSsms.ps1
@@ -39,7 +39,7 @@ Function Get-MicrosoftSsms {
         # Build an output object by selecting installer entries from the feed
         If ($xmlDocument -is [System.XML.XMLDocument]) {
             ForEach ($entry in $xmlDocument.feed.entry) {
-                Write-Warning -Message "$($MyInvocation.MyCommand): Version returned from the update feed: $($entry.Component.version)."
+                Write-Warning -Message "$($MyInvocation.MyCommand): Version returned from the update feed: $($entry.Component.version). See https://stealthpuppy.com/Evergreen/knownissues.html for more information."
 
                 ForEach ($components in ($entry.component | Where-Object { $_.name -eq $res.Get.Download.MatchName })) {
                     ForEach ($language in $res.Get.Download.Language.GetEnumerator()) {

--- a/Evergreen/Manifests/AdobeAcrobatReaderDC.json
+++ b/Evergreen/Manifests/AdobeAcrobatReaderDC.json
@@ -20,7 +20,20 @@
                 "Japanese",
                 "Korean",
                 "Norwegian",
-                "Spanish"
+                "Spanish",
+                "Swedish",
+                "Basque",
+                "Catalan",
+                "Croatian",
+                "Czech",
+                "Hungarian",
+                "Polish",
+                "Romanian",
+                "Russian",
+                "Slovakian",
+                "Slovenian",
+                "Turkish",
+                "Ukrainian"
             ],
             "Headers": {
                 "Sec-Fetch-Dest": "empty",

--- a/Evergreen/Manifests/FoxitReader.json
+++ b/Evergreen/Manifests/FoxitReader.json
@@ -1,22 +1,31 @@
 {
-	"Name": "Foxit Reader",
-	"Source": "https://www.foxitsoftware.com/pdf-reader/",
-	"Get": {
-		"Uri": "https://www.foxitsoftware.com/portal/download/getdownloadform.html?retJson=1&product=Foxit-Reader&platform=Windows&formId=download-reader",
-		"ContentType": "text/html; charset=UTF-8",
-		"DateTimePattern": "MM/dd/yy",
-		"DownloadUri": "https://www.foxitsoftware.com/downloads/latest.html?product=Foxit-Reader&platform=Windows&version=#Version&package_type=#Package&language=#Language",
-		"DownloadMsi": "https://www.foxitsoftware.com/downloads/latest.html?product=Foxit-Enterprise-Reader&platform=Windows&version=#Version&package_type=msi&language=#Language&distID="
-	},
-	"Install": {
-		"Setup": "FoxitReader*.exe",
-		"Physical": {
-			"Arguments": "DESKTOP_SHORTCUT=\"0\" MAKEDEFAULT=\"0\" VIEWINBROWSER=\"0\" LAUNCHCHECKDEFAULT=\"0\" AUTO_UPDATE=\"1\" /passive /norestart /qn",
-			"PostInstall": []
-		},
-		"Virtual": {
-			"Arguments": "DESKTOP_SHORTCUT=\"0\" MAKEDEFAULT=\"0\" VIEWINBROWSER=\"0\" LAUNCHCHECKDEFAULT=\"0\" AUTO_UPDATE=\"0\" /passive /norestart /qn",
-			"PostInstall": []
-		}
-	}
+    "Name": "Foxit Reader",
+    "Source": "https://www.foxitsoftware.com/pdf-reader/",
+    "Get": {
+        "Update": {
+            "Uri": "https://www.foxitsoftware.com/portal/download/getdownloadform.html?retJson=1&product=Foxit-Reader&platform=Windows&formId=download-reader",
+            "ContentType": "text/html; charset=UTF-8",
+            "SkipLanguages": [
+                "Elex",
+                "Portuguese(Portugal)",
+                "Turkish"
+            ],
+			"DateTimePattern": "MM/dd/yy"
+        },
+        "Download": {
+            "Exe": "https://www.foxitsoftware.com/downloads/latest.html?product=Foxit-Reader&platform=Windows&version=#Version&package_type=#Package&language=#Language",
+            "Uri": "https://www.foxitsoftware.com/downloads/latest.html?product=Foxit-Enterprise-Reader&platform=Windows&version=#Version&package_type=msi&language=#Language&distID="
+        }
+    },
+    "Install": {
+        "Setup": "FoxitReader*.exe",
+        "Physical": {
+            "Arguments": "DESKTOP_SHORTCUT=\"0\" MAKEDEFAULT=\"0\" VIEWINBROWSER=\"0\" LAUNCHCHECKDEFAULT=\"0\" AUTO_UPDATE=\"1\" /passive /norestart /qn",
+            "PostInstall": []
+        },
+        "Virtual": {
+            "Arguments": "DESKTOP_SHORTCUT=\"0\" MAKEDEFAULT=\"0\" VIEWINBROWSER=\"0\" LAUNCHCHECKDEFAULT=\"0\" AUTO_UPDATE=\"0\" /passive /norestart /qn",
+            "PostInstall": []
+        }
+    }
 }

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,12 @@ toc: false
 permalink: changelog.html
 summary: Changes, updates, fixes and breaking changes in each Evergreen version.
 ---
+## VERSION
+
+* Changes `FoxitReader` to return MSI installers instead of EXEs. Removes Elex, Portuguese (Portugal), and Turkish language support from this application because the installers returned are out of date.
+* Adds the following languages to `AdobeAcrobatReaderDC`: Swedish, Basque, Catalan, Croatian, Czech, Hungarian, Polish, Romanian, Russian, Slovakian, Slovenian, Turkish, Ukrainian
+* Adds a known issues list to the documentation: [https://stealthpuppy.com/Evergreen/knownissues.html](https://stealthpuppy.com/Evergreen/knownissues.html)
+
 ## 2104.348
 
 * Modifies `Get-EvergreenApp` to load internal per-application functions on demand, instead of the module loading all of these function into memory at import

--- a/docs/knownissues.md
+++ b/docs/knownissues.md
@@ -34,3 +34,7 @@ The product release feed used by the Microsoft SQL Server Management Studio (e.g
 `VMwareHorizonClient` may not always return the current release - the major version property in the VMware Horizon Client software update data does not use easily sortable versioning.
 
 `VMwareHorizonClient` returns the Horizon Client in .tar format. This the same URL used when the Horizon Client updates itself - you will need to unpack the .tar file to retrieve the executable installer.
+
+### 7zip
+
+The 32-bit installers returned by `7Zip` link to a SourceForge download page instead of the file directly.

--- a/docs/knownissues.md
+++ b/docs/knownissues.md
@@ -1,0 +1,36 @@
+﻿---
+title: "Known Issues"
+keywords: evergreen
+tags: [issues]
+sidebar: home_sidebar
+toc: false
+permalink: knownissues.html
+summary: 
+---
+## Public Functions
+
+### Get-EvergreenApp
+
+`Get-EvergreenApp` does not fully support proxy servers. This will be fixed in a future release.
+
+### Save-EvergreenApp
+
+The folder structure created by `Save-EvergreenApp` uses a static set of properties from the input object. This path cannot currently by customised by the user.
+
+`Save-EvergreenApp` does not fully support proxy servers. This will be fixed in a future release.
+
+## Application Functions
+
+### AdobeAcrobatReaderDC
+
+The JSON data returned from the Adobe Acrobat Reader DC download URL (`https://get.adobe.com/reader/webservices/json/standalone/`) returns extraneous data for the following languages, thus they have not been included in the manifest: Portuguese, Chinese (Simplified), Chinese (Traditional)
+
+### MicrosoftSsms
+
+The product release feed used by the Microsoft SQL Server Management Studio (e.g., [https://download.microsoft.com/download/3/f/d/3fd533f5-fdfc-407d-98a6-d5deb214d13b/SSMS_PRODUCTRELEASESFEED.xml](https://download.microsoft.com/download/3/f/d/3fd533f5-fdfc-407d-98a6-d5deb214d13b/SSMS_PRODUCTRELEASESFEED.xml)) includes the internal build number of the SQL Server Management Studio and not the display version, thus the version return will be similar to `15.0.18369.0` instead of the display version: `18.9.1`. See [Download SQL Server Management Studio (SSMS)](https://docs.microsoft.com/en-us/sql/ssms/download-sql-server-management-studio-ssms?view=sql-server-ver15) for more info.
+
+### VMwareHorizonClient
+
+`VMwareHorizonClient` may not always return the current release - the major version property in the VMware Horizon Client software update data does not use easily sortable versioning.
+
+`VMwareHorizonClient` returns the Horizon Client in .tar format. This the same URL used when the Horizon Client updates itself - you will need to unpack the .tar file to retrieve the executable installer.

--- a/docs/knownissues.md
+++ b/docs/knownissues.md
@@ -38,3 +38,11 @@ The product release feed used by the Microsoft SQL Server Management Studio (e.g
 ### 7zip
 
 The 32-bit installers returned by `7Zip` link to a SourceForge download page instead of the file directly.
+
+### Zoom
+
+`Zoom` returns versions as `Latest` for some downloads - the source used by this function does not provide a method for determining the version number.
+
+### CitrixWorkspaceApp
+
+The version of the HDX RealTime Media Engine for Microsoft Skype for Business for Windows returned by `CitrixWorkspaceApp` is out of date. This is the version of the HDX RTME that is returned by the Workspace App update feed ([https://downloadplugins.citrix.com/ReceiverUpdates/Prod/catalog_win.xml](https://downloadplugins.citrix.com/ReceiverUpdates/Prod/catalog_win.xml)). Use `CitrixWorkspaceAppFeed` to find the latest version of the HDX RTME. Note that returns a link to the download page and not the installer directly.


### PR DESCRIPTION
* Changes `FoxitReader` to return MSI installers instead of EXEs. Removes Elex, Portuguese (Portugal), and Turkish language support from this application because the installers returned are out of date.
* Adds the following languages to `AdobeAcrobatReaderDC`: Swedish, Basque, Catalan, Croatian, Czech, Hungarian, Polish, Romanian, Russian, Slovakian, Slovenian, Turkish, Ukrainian
* Adds a known issues list to the documentation: [https://stealthpuppy.com/Evergreen/knownissues.html](https://stealthpuppy.com/Evergreen/knownissues.html)