### PR TITLE
Development May 26 2021

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: false
 contact_links:
   - name: Review known issues
-    url: https://stealthpuppy.com/Evergreen/knownissues.html
+    url: https://stealthpuppy.com/evergreen/knownissues.html
     about: Please ensure you have read the Evergreen known issues list before creating an issue.

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,11 +1,28 @@
 {
     "files.encoding": "utf8bom",
     "cSpell.words": [
+        "Anki",
+        "Atlassian",
+        "Bitwarden",
+        "Cyberduck",
+        "Elex",
         "Foxit",
+        "Greenshot",
         "Karakun",
+        "MAML",
+        "MSIX",
+        "Nomacs",
+        "Rfor",
         "Sobject",
+        "Ssms",
+        "Stefans",
+        "Telerik",
+        "Twork",
+        "Vercel",
         "Wireshark",
         "currentversion",
+        "fwlink",
+        "iainbrighton",
         "msixbinary",
         "notin"
     ]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,3 @@
 # Change log
 
-The Evergreen change log can now be found here: [https://stealthpuppy.com/Evergreen/changelog.html](https://stealthpuppy.com/Evergreen/changelog.html).
+The Evergreen change log can now be found here: [https://stealthpuppy.com/evergreen/changelog.html](https://stealthpuppy.com/evergreen/changelog.html).

--- a/Evergreen/Apps/Get-CitrixWorkspaceApp.ps1
+++ b/Evergreen/Apps/Get-CitrixWorkspaceApp.ps1
@@ -55,6 +55,6 @@
                 }
             }
         }
-        Write-Warning -Message "$($MyInvocation.MyCommand): HDX RTME for Windows version returned is out of date. See https://stealthpuppy.com/Evergreen/changelog.html for more information."
+        Write-Warning -Message "$($MyInvocation.MyCommand): HDX RTME for Windows version returned is out of date. See https://stealthpuppy.com/evergreen/changelog.html for more information."
     }
 }

--- a/Evergreen/Apps/Get-FoxitReader.ps1
+++ b/Evergreen/Apps/Get-FoxitReader.ps1
@@ -46,7 +46,7 @@ Function Get-FoxitReader {
                     Version  = $Version
                     Date     = ConvertTo-DateTime -DateTime $updateFeed.package_info.release -Pattern $res.Get.Update.DateTimePattern
                     Language = $language
-                    URI      = $redirectUrl.ResponseUri
+                    URI      = $redirectUrl.ResponseUri.AbsoluteUri
                 }
                 Write-Output -InputObject $PSObject
             }

--- a/Evergreen/Apps/Get-LogMeInGoToOpener.ps1
+++ b/Evergreen/Apps/Get-LogMeInGoToOpener.ps1
@@ -36,7 +36,7 @@
     $PSObject = [PSCustomObject] @{
         Version = $Version
         Date    = $Response.LastModified
-        URI     = $Response.ResponseUri
+        URI     = $Response.ResponseUri.AbsoluteUri
     }
     Write-Output -InputObject $PSObject
 }

--- a/Evergreen/Apps/Get-MicrosoftSsms.ps1
+++ b/Evergreen/Apps/Get-MicrosoftSsms.ps1
@@ -39,7 +39,7 @@ Function Get-MicrosoftSsms {
         # Build an output object by selecting installer entries from the feed
         If ($xmlDocument -is [System.XML.XMLDocument]) {
             ForEach ($entry in $xmlDocument.feed.entry) {
-                Write-Warning -Message "$($MyInvocation.MyCommand): Version returned from the update feed: $($entry.Component.version). See https://stealthpuppy.com/Evergreen/knownissues.html for more information."
+                Write-Warning -Message "$($MyInvocation.MyCommand): Version returned from the update feed: $($entry.Component.version). See https://stealthpuppy.com/evergreen/knownissues.html for more information."
 
                 ForEach ($components in ($entry.component | Where-Object { $_.name -eq $res.Get.Download.MatchName })) {
                     ForEach ($language in $res.Get.Download.Language.GetEnumerator()) {

--- a/Evergreen/Apps/Get-MicrosoftSsms.ps1
+++ b/Evergreen/Apps/Get-MicrosoftSsms.ps1
@@ -46,7 +46,7 @@ Function Get-MicrosoftSsms {
 
                         # Follow the download link which will return a 301
                         $Uri = $res.Get.Download.Uri -replace $res.Get.Download.ReplaceText, $res.Get.Download.Language[$language.key]
-                        $ResponseUri = (Resolve-SystemNetWebRequest -Uri $Uri).ResponseUri.AbsoluteUri
+                        $ResponseUri = Resolve-SystemNetWebRequest -Uri $Uri
             
                         # Check returned URL. It should be a go.microsoft.com/fwlink/?linkid style link
                         If ($Null -ne $ResponseUri) {
@@ -57,7 +57,7 @@ Function Get-MicrosoftSsms {
                                 Date     = ConvertTo-DateTime -DateTime ($entry.updated.Split(".")[0]) -Pattern $res.Get.Update.DatePattern
                                 Title    = $entry.Title
                                 Language = $language.key
-                                URI      = $ResponseUri
+                                URI      = $ResponseUri.ResponseUri.AbsoluteUri
                             }
                             Write-Output -InputObject $PSObject
                         }

--- a/Evergreen/Apps/Get-MicrosoftVisualStudio.ps1
+++ b/Evergreen/Apps/Get-MicrosoftVisualStudio.ps1
@@ -22,14 +22,14 @@ Function Get-MicrosoftVisualStudio {
     )
 
     # Resolve the update feed from the initial URI
-    $ResolvedUrl = (Resolve-SystemNetWebRequest -Uri $res.Get.Update.Uri).ResponseUri.AbsoluteUri
+    $ResolvedUrl = Resolve-SystemNetWebRequest -Uri $res.Get.Update.Uri
     If ($ResolvedUrl) {
         try {
             # Get details from the update feed
-            $updateFeed = Invoke-RestMethodWrapper -Uri $ResolvedUrl
+            $updateFeed = Invoke-RestMethodWrapper -Uri $ResolvedUrl.ResponseUri.AbsoluteUri
         }
         catch {
-            Throw "$($MyInvocation.MyCommand): Failed to resolve update feed: $ResolvedUrl."
+            Throw "$($MyInvocation.MyCommand): Failed to resolve update feed: $($ResolvedUrl.ResponseUri.AbsoluteUri)."
         }
         finally {
             # Build the output object/s

--- a/Evergreen/Apps/Get-RingCentral.ps1
+++ b/Evergreen/Apps/Get-RingCentral.ps1
@@ -39,14 +39,14 @@ Function Get-RingCentral {
         ForEach ($installer in $res.Get.Download[$platform].Keys) {
 
             # Follow the download link which will return a 301/302
-            $redirectUrl = (Resolve-SystemNetWebRequest -Uri $res.Get.Download[$platform][$installer]).ResponseUri.AbsoluteUri
+            $redirectUrl = Resolve-SystemNetWebRequest -Uri $res.Get.Download[$platform][$installer]
 
             # Match the URL without the text after the ?
             try {
-                $Url = [RegEx]::Match($redirectUrl, $res.Get.MatchUrl).Captures.Groups[1].Value
+                $Url = [RegEx]::Match($redirectUrl.ResponseUri.AbsoluteUri, $res.Get.MatchUrl).Captures.Groups[1].Value
             }
             catch {
-                $Url = $redirectUrl
+                $Url = $redirectUrl.ResponseUri.AbsoluteUri
             }
 
             # Match version number from the download URL

--- a/Evergreen/Apps/Get-Slack.ps1
+++ b/Evergreen/Apps/Get-Slack.ps1
@@ -24,11 +24,11 @@ Function Get-Slack {
         ForEach ($architecture in $res.Get.Download[$platform].Keys) {
 
             # Follow the download link which will return a 301/302
-            $Url = (Resolve-SystemNetWebRequest -Uri $res.Get.Download[$platform][$architecture]).ResponseUri.AbsoluteUri
+            $redirectUrl = Resolve-SystemNetWebRequest -Uri $res.Get.Download[$platform][$architecture]
 
             # Match version number from the download URL
             try {
-                $Version = [RegEx]::Match($Url, $res.Get.MatchVersion).Captures.Groups[0].Value
+                $Version = [RegEx]::Match($redirectUrl.ResponseUri.AbsoluteUri, $res.Get.MatchVersion).Captures.Groups[0].Value
             }
             catch {
                 $Version = "Latest"
@@ -39,7 +39,7 @@ Function Get-Slack {
                 Version      = $Version
                 Platform     = $platform
                 Architecture = $architecture
-                URI          = $Url
+                URI          = $redirectUrl.ResponseUri.AbsoluteUri
             }
             Write-Output -InputObject $PSObject
         }

--- a/Evergreen/Apps/Get-VMwareHorizonClient.ps1
+++ b/Evergreen/Apps/Get-VMwareHorizonClient.ps1
@@ -58,28 +58,14 @@
 
     # Download the version specific update XML in Gzip format
     If ($Null -ne $LatestVersion) {
-        #TODO: turn this into a function
-        try {
-            $Url = "$($res.Get.Download.Uri)$($LatestVersion.Url.TrimStart("../"))"
-            $GZipFile = Join-Path -Path $([System.IO.Path]::GetTempPath()) -ChildPath (Split-Path -Path $Url -Leaf)
-            $params = @{
-                Uri             = $Url
-                OutFile         = $GZipFile
-                UseBasicParsing = $True
-                UserAgent       = [Microsoft.PowerShell.Commands.PSUserAgent]::Chrome
-            }
-            Invoke-WebRequest @params
-        }
-        catch {
-            Throw "$($MyInvocation.MyCommand): Failed to download from: $Url, to $GZipFile."
-        }
+        $GZipFile = Save-File -Uri "$($res.Get.Download.Uri)$($LatestVersion.Url.TrimStart("../"))"
     }
     Else {
         Throw "$($MyInvocation.MyCommand): Failed to determine metadata property for the Horizon Client latest version."
     }
     
     # Expand the downloaded Gzip file to get the XMl file
-    $ExpandFile = Expand-GzipArchive -Path $GZipFile
+    $ExpandFile = Expand-GzipArchive -Path $GZipFile.FullName
 
     # Get the version specific details from the XML file
     try {
@@ -92,8 +78,8 @@
         Throw "$($MyInvocation.MyCommand): Failed to convert metadata XML."
     }
     finally {
-        Write-Verbose -Message "$($MyInvocation.MyCommand): Delete: $GZipFile."
-        Remove-Item -Path $GZipFile -ErrorAction "SilentlyContinue"
+        Write-Verbose -Message "$($MyInvocation.MyCommand): Delete: $($GZipFile.FullName)."
+        Remove-Item -Path $GZipFile.FullName -ErrorAction "SilentlyContinue"
         Write-Verbose -Message "$($MyInvocation.MyCommand): Delete: $ExpandFile."
         Remove-Item -Path $ExpandFile -ErrorAction "SilentlyContinue"
     }

--- a/Evergreen/Apps/Get-Zoom.ps1
+++ b/Evergreen/Apps/Get-Zoom.ps1
@@ -24,14 +24,14 @@ Function Get-Zoom {
         ForEach ($installer in $res.Get.Download[$platform].Keys) {
 
             # Follow the download link which will return a 301/302
-            $redirectUrl = (Resolve-SystemNetWebRequest -Uri $res.Get.Download[$platform][$installer]).ResponseUri.AbsoluteUri
+            $redirectUrl = Resolve-SystemNetWebRequest -Uri $res.Get.Download[$platform][$installer]
 
             # Match the URL without the text after the ?
             try {
-                $Url = [RegEx]::Match($redirectUrl, $res.Get.MatchUrl).Captures.Groups[1].Value
+                $Url = [RegEx]::Match($redirectUrl.ResponseUri.AbsoluteUri, $res.Get.MatchUrl).Captures.Groups[1].Value
             }
             catch {
-                $Url = $redirectUrl
+                $Url = $redirectUrl.ResponseUri.AbsoluteUri
             }
 
             # Match version number from the download URL

--- a/Evergreen/Evergreen.json
+++ b/Evergreen/Evergreen.json
@@ -34,6 +34,6 @@
 	},
 	"Uri": {
 		"Project": "https://github.com/aaronparker/Evergreen/",
-		"Documentation": "https://stealthpuppy.com/Evergreen/"
+		"Documentation": "https://stealthpuppy.com/evergreen/"
 	}
 }

--- a/Evergreen/Evergreen.psd1
+++ b/Evergreen/Evergreen.psd1
@@ -111,7 +111,7 @@ PrivateData = @{
         IconUri = 'https://raw.githubusercontent.com/aaronparker/Evergreen/main/img/EvergreenLeaf.png'
 
         # ReleaseNotes of this module
-        ReleaseNotes = 'https://stealthpuppy.com/Evergreen/changelog.html'
+        ReleaseNotes = 'https://stealthpuppy.com/evergreen/changelog.html'
 
         # Prerelease string of this module
         # Prerelease = ''

--- a/Evergreen/Manifests/VMwareHorizonClient.json
+++ b/Evergreen/Manifests/VMwareHorizonClient.json
@@ -5,7 +5,8 @@
 		"Update": {
 			"Uri": "https://softwareupdate.vmware.com/horizon-clients/viewcrt-mac/viewcrt-windows.xml",
 			"ContentType": "application/xml",
-			"Property": "metaList.metadata"
+			"Property": "metaList.metadata",
+			"MatchVersion": "(\\d+(\\.\\d+){1,4}).*"
 		},
 		"Download": {
 			"Uri": "https://softwareupdate.vmware.com/horizon-clients/",

--- a/Evergreen/Private/Save-File.ps1
+++ b/Evergreen/Private/Save-File.ps1
@@ -1,0 +1,40 @@
+﻿Function Save-File {
+    <#
+        .SYNOPSIS
+            Downloads a file with Invoke-WebRequest and returns the downloaded file path.
+    #>
+    [OutputType([System.Array])]
+    [CmdletBinding(SupportsShouldProcess = $False)]
+    param (
+        [Parameter(Mandatory = $True, Position = 0)]
+        [ValidateNotNull()]
+        [System.String] $Uri
+    )
+    
+    # Create an OutFile to save the download to
+    $OutFile = Join-Path -Path $([System.IO.Path]::GetTempPath()) -ChildPath (Split-Path -Path $Uri -Leaf)
+    Write-Verbose -Message "$($MyInvocation.MyCommand): Using save path: $OutFile."
+
+    try {
+        $params = @{
+            Uri             = $Uri
+            OutFile         = $OutFile
+            UseBasicParsing = $True
+            UserAgent       = [Microsoft.PowerShell.Commands.PSUserAgent]::Chrome
+        }
+        If (Test-PSCore) {
+            $params.SslProtocol = "Tls12"
+        }
+        Else {
+            $SslProtocol = "Tls12"
+            [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::$SslProtocol
+        }
+        Invoke-WebRequest @params
+    }
+    catch {
+        Throw "$($MyInvocation.MyCommand): $($_.Exception.Message)."
+    }
+
+    # Write the OutFile properties to the pipeline
+    Write-Output -InputObject (Get-ChildItem -Path $OutFile)
+}

--- a/Evergreen/Public/Export-EvergreenManifest.ps1
+++ b/Evergreen/Public/Export-EvergreenManifest.ps1
@@ -3,7 +3,7 @@ Function Export-EvergreenManifest {
         .EXTERNALHELP Evergreen-help.xml
     #>
     [OutputType([System.Management.Automation.PSObject])]
-    [CmdletBinding(SupportsShouldProcess = $False, HelpURI = "https://stealthpuppy.com/Evergreen/")]
+    [CmdletBinding(SupportsShouldProcess = $False, HelpURI = "https://stealthpuppy.com/evergreen/")]
     param (
         [Parameter(Mandatory = $True, Position = 0)]
         [ValidateNotNull()]

--- a/Evergreen/Public/Find-EvergreenApp.ps1
+++ b/Evergreen/Public/Find-EvergreenApp.ps1
@@ -3,7 +3,7 @@
         .EXTERNALHELP Evergreen-help.xml
     #>
     [OutputType([System.Management.Automation.PSObject])]
-    [CmdletBinding(SupportsShouldProcess = $False, HelpURI = "https://stealthpuppy.com/Evergreen/find.html")]
+    [CmdletBinding(SupportsShouldProcess = $False, HelpURI = "https://stealthpuppy.com/evergreen/find.html")]
     [Alias("fea")]
     param (
         [Parameter(

--- a/Evergreen/Public/Get-EvergreenApp.ps1
+++ b/Evergreen/Public/Get-EvergreenApp.ps1
@@ -3,7 +3,7 @@ Function Get-EvergreenApp {
         .EXTERNALHELP Evergreen-help.xml
     #>
     [OutputType([System.Management.Automation.PSObject])]
-    [CmdletBinding(SupportsShouldProcess = $False, HelpURI = "https://stealthpuppy.com/Evergreen/use.html")]
+    [CmdletBinding(SupportsShouldProcess = $False, HelpURI = "https://stealthpuppy.com/evergreen/use.html")]
     [Alias("gea")]
     param (
         [Parameter(

--- a/Evergreen/Public/Save-EvergreenApp.ps1
+++ b/Evergreen/Public/Save-EvergreenApp.ps1
@@ -3,7 +3,7 @@ Function Save-EvergreenApp {
         .EXTERNALHELP Evergreen-help.xml
     #>
     [OutputType([System.Management.Automation.PSObject])]
-    [CmdletBinding(SupportsShouldProcess = $True, HelpURI = "https://stealthpuppy.com/Evergreen/save.html")]
+    [CmdletBinding(SupportsShouldProcess = $True, HelpURI = "https://stealthpuppy.com/evergreen/save.html")]
     [Alias("sea")]
     param (
         [Parameter(Mandatory = $True, Position = 0, ValueFromPipeline)]

--- a/Evergreen/en-US/Evergreen-help.xml
+++ b/Evergreen/en-US/Evergreen-help.xml
@@ -80,7 +80,7 @@
     <command:relatedLinks>
       <maml:navigationLink>
         <maml:linkText>Getting started with Evergreen:</maml:linkText>
-        <maml:uri>https://stealthpuppy.com/Evergreen/</maml:uri>
+        <maml:uri>https://stealthpuppy.com/evergreen/</maml:uri>
       </maml:navigationLink>
     </command:relatedLinks>
   </command:command>
@@ -178,7 +178,7 @@
     <command:relatedLinks>
       <maml:navigationLink>
         <maml:linkText>Find supported applications:</maml:linkText>
-        <maml:uri>https://stealthpuppy.com/Evergreen/find.html</maml:uri>
+        <maml:uri>https://stealthpuppy.com/evergreen/find.html</maml:uri>
       </maml:navigationLink>
     </command:relatedLinks>
   </command:command>
@@ -309,7 +309,7 @@ URI          : https://msedge.sf.dl.delivery.mp.microsoft.com/filestreamingservi
     <command:relatedLinks>
       <maml:navigationLink>
         <maml:linkText>Use Evergreen:</maml:linkText>
-        <maml:uri>https://stealthpuppy.com/Evergreen/use.html</maml:uri>
+        <maml:uri>https://stealthpuppy.com/evergreen/use.html</maml:uri>
       </maml:navigationLink>
     </command:relatedLinks>
   </command:command>
@@ -563,7 +563,7 @@ URI          : https://msedge.sf.dl.delivery.mp.microsoft.com/filestreamingservi
     <command:relatedLinks>
       <maml:navigationLink>
         <maml:linkText>Download application installers:</maml:linkText>
-        <maml:uri>https://stealthpuppy.com/Evergreen/save.html</maml:uri>
+        <maml:uri>https://stealthpuppy.com/evergreen/save.html</maml:uri>
       </maml:navigationLink>
     </command:relatedLinks>
   </command:command>

--- a/README.md
+++ b/README.md
@@ -47,11 +47,11 @@ Evergreen's focus is on integration for PowerShell scripts to provide product ve
 
 ## Documentation
 
-Documentation for Evergreen, including usage examples, is located here: [https://stealthpuppy.com/evergreen/index.html](https://stealthpuppy.com/Evergreen/index.html).
+Documentation for Evergreen, including usage examples, is located here: [https://stealthpuppy.com/evergreen/index.html](https://stealthpuppy.com/evergreen/index.html).
 
 ## Versioning
 
-The module uses a version notation that follows: YearMonth.Build. It is expected that the module will have changes on a regular basis, so the version numbering is intended to make it as simple as possible to understand when the last update was made. See the [CHANGELOG](https://stealthpuppy.com/Evergreen/changelog.html) for details on changes introduced in each version.
+The module uses a version notation that follows: YearMonth.Build. It is expected that the module will have changes on a regular basis, so the version numbering is intended to make it as simple as possible to understand when the last update was made. See the [CHANGELOG](https://stealthpuppy.com/evergreen/changelog.html) for details on changes introduced in each version.
 
 ## Installing the Module
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -42,7 +42,7 @@ summary: Changes, updates, fixes, and breaking changes in each Evergreen version
 
 * Changes `FoxitReader` to return MSI installers instead of EXEs. Removes Elex, Portuguese (Portugal), and Turkish language support from this application because the installers returned are out of date.
 * Adds the following languages to `AdobeAcrobatReaderDC`: Swedish, Basque, Catalan, Croatian, Czech, Hungarian, Polish, Romanian, Russian, Slovakian, Slovenian, Turkish, Ukrainian
-* Adds a known issues list to the documentation: [https://stealthpuppy.com/Evergreen/knownissues.html](https://stealthpuppy.com/Evergreen/knownissues.html)
+* Adds a known issues list to the documentation: [https://stealthpuppy.com/evergreen/knownissues.html](https://stealthpuppy.com/evergreen/knownissues.html)
 
 ## 2104.348
 
@@ -56,7 +56,7 @@ summary: Changes, updates, fixes, and breaking changes in each Evergreen version
 
 ## 2104.337
 
-* **BREAKING CHANGE**: This version removes the `Get-` function for each application and introduces `Get-EvergreenApp`. See the docs site on how to use the new functions [https://stealthpuppy.com/Evergreen/](https://stealthpuppy.com/Evergreen/)
+* **BREAKING CHANGE**: This version removes the `Get-` function for each application and introduces `Get-EvergreenApp`. See the docs site on how to use the new functions [https://stealthpuppy.com/evergreen/](https://stealthpuppy.com/evergreen/)
 * Adds `Get-EvergreenApp`, `Find-EvergreenApp` and `Save-EvergreenApp`
 * Adds file type to SourceForge applications
 * Re-instates `ControlUpAgent` and `ControlUpConsole`
@@ -103,7 +103,7 @@ summary: Changes, updates, fixes, and breaking changes in each Evergreen version
 * Updates `Get-MicrosoftWvdRemoteDesktop` to output the `URI` property value in the format `https://query.prod.cms.rt.microsoft.com/cms/api/am/binary/RE4MntQ` instead of the original fwlink source URL (e.g. `https://go.microsoft.com/fwlink/?linkid=2068602`)
 * Updates the following functions to use `Invoke-RestMethod` (via `Invoke-RestMethodWrapper`) instead of `Invoke-WebRequest` to simplify code and fix an issue where some functions where returning `Version` as a PSObject instead of System.String ([#109](https://github.com/aaronparker/Evergreen/issues/109))
   * `Get-AtlassianBitbucket`, `Get-Cyberduck`, `Get-FileZilla`, `Get-Fork`, `Get-RingCentral`, `Get-ScooterBeyondCompare`, `Get-SumatraPDFReader`, `Get-VideoLanVlcPlayer`
-* Updates module `ReleaseNotes` location to: [https://stealthpuppy.com/Evergreen/changelog.html](https://stealthpuppy.com/Evergreen/changelog.html)
+* Updates module `ReleaseNotes` location to: [https://stealthpuppy.com/evergreen/changelog.html](https://stealthpuppy.com/evergreen/changelog.html)
 
 ## 2101.281
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,11 @@ toc: false
 permalink: changelog.html
 summary: Changes, updates, fixes, and breaking changes in each Evergreen version.
 ---
+### VERSION
+
+* Update `VMwareHorizonClient` with additional filtering to select the latest version correctly [#161](https://github.com/aaronparker/evergreen/issues/161)
+* Add internal function `Save-File` to download a URL with `Invoke-WebRequest` and return the downloaded file path
+
 ## 2105.383
 
 * Adds `CiscoWebEx` ([#141](https://github.com/aaronparker/Evergreen/issues/141)), `VeraCrypt` ([#160](https://github.com/aaronparker/Evergreen/issues/160)), `KarakunOpenWebStart` ([#163](https://github.com/aaronparker/Evergreen/issues/163))

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,8 +9,10 @@ summary: Changes, updates, fixes, and breaking changes in each Evergreen version
 ---
 ### VERSION
 
-* Update `VMwareHorizonClient` with additional filtering to select the latest version correctly [#161](https://github.com/aaronparker/evergreen/issues/161)
+* Update `VMwareHorizonClient` with additional filtering to select the latest version correctly to address [#161](https://github.com/aaronparker/evergreen/issues/161)
 * Add internal function `Save-File` to download a URL with `Invoke-WebRequest` and return the downloaded file path
+* Update internal application functions for consistent use of `Resolve-SystemNetWebRequest` to address [#174](https://github.com/aaronparker/evergreen/issues/174) - `Get-FoxitReader`, `Get-LogMeInGoToOpener`, `Get-MicrosoftSsms`, `Get-MicrosoftVisualStudio`, `Get-RingCentral`, `Get-Slack`
+* Update references to documentation site `https://stealthpuppy.com/Evergreen` to `https://stealthpuppy.com/evergreen`
 
 ## 2105.383
 
@@ -105,7 +107,7 @@ summary: Changes, updates, fixes, and breaking changes in each Evergreen version
 ## 2102.286
 
 * Adds the `ARM` architecture to `Get-MicrosoftVisualStudioCode`
-* Updates `Get-MicrosoftWvdRemoteDesktop` to output the `URI` property value in the format `https://query.prod.cms.rt.microsoft.com/cms/api/am/binary/RE4MntQ` instead of the original fwlink source URL (e.g. `https://go.microsoft.com/fwlink/?linkid=2068602`)
+* Updates `Get-MicrosoftWvdRemoteDesktop` to output the `URI` property value in the format `https://query.prod.cms.rt.microsoft.com/cms/api/am/binary/RE4MntQ` instead of the original `fwlink` source URL (e.g. `https://go.microsoft.com/fwlink/?linkid=2068602`)
 * Updates the following functions to use `Invoke-RestMethod` (via `Invoke-RestMethodWrapper`) instead of `Invoke-WebRequest` to simplify code and fix an issue where some functions where returning `Version` as a PSObject instead of System.String ([#109](https://github.com/aaronparker/Evergreen/issues/109))
   * `Get-AtlassianBitbucket`, `Get-Cyberduck`, `Get-FileZilla`, `Get-Fork`, `Get-RingCentral`, `Get-ScooterBeyondCompare`, `Get-SumatraPDFReader`, `Get-VideoLanVlcPlayer`
 * Updates module `ReleaseNotes` location to: [https://stealthpuppy.com/evergreen/changelog.html](https://stealthpuppy.com/evergreen/changelog.html)

--- a/help/en-US/Export-EvergreenManifest.md
+++ b/help/en-US/Export-EvergreenManifest.md
@@ -1,7 +1,7 @@
 ---
 external help file: Evergreen-help.xml
 Module Name: Evergreen
-online version: https://stealthpuppy.com/Evergreen/
+online version: https://stealthpuppy.com/evergreen/
 schema: 2.0.0
 ---
 
@@ -69,4 +69,4 @@ Twitter: @stealthpuppy
 
 ## RELATED LINKS
 
-[Getting started with Evergreen:](https://stealthpuppy.com/Evergreen/)
+[Getting started with Evergreen:](https://stealthpuppy.com/evergreen/)

--- a/help/en-US/Find-EvergreenApp.md
+++ b/help/en-US/Find-EvergreenApp.md
@@ -1,7 +1,7 @@
 ---
 external help file: Evergreen-help.xml
 Module Name: Evergreen
-online version: https://stealthpuppy.com/Evergreen/find.html
+online version: https://stealthpuppy.com/evergreen/find.html
 schema: 2.0.0
 ---
 
@@ -88,4 +88,4 @@ Twitter: @stealthpuppy
 
 ## RELATED LINKS
 
-[Find supported applications:](https://stealthpuppy.com/Evergreen/find.html)
+[Find supported applications:](https://stealthpuppy.com/evergreen/find.html)

--- a/help/en-US/Get-EvergreenApp.md
+++ b/help/en-US/Get-EvergreenApp.md
@@ -1,7 +1,7 @@
 ---
 external help file: Evergreen-help.xml
 Module Name: Evergreen
-online version: https://stealthpuppy.com/Evergreen/use.html
+online version: https://stealthpuppy.com/evergreen/use.html
 schema: 2.0.0
 ---
 
@@ -129,4 +129,4 @@ Twitter: @stealthpuppy
 
 ## RELATED LINKS
 
-[Use Evergreen:](https://stealthpuppy.com/Evergreen/use.html)
+[Use Evergreen:](https://stealthpuppy.com/evergreen/use.html)

--- a/help/en-US/Save-EvergreenApp.md
+++ b/help/en-US/Save-EvergreenApp.md
@@ -1,7 +1,7 @@
 ---
 external help file: Evergreen-help.xml
 Module Name: Evergreen
-online version: https://stealthpuppy.com/Evergreen/save.html
+online version: https://stealthpuppy.com/evergreen/save.html
 schema: 2.0.0
 ---
 
@@ -195,4 +195,4 @@ Twitter: @stealthpuppy
 
 ## RELATED LINKS
 
-[Download application installers:](https://stealthpuppy.com/Evergreen/save.html)
+[Download application installers:](https://stealthpuppy.com/evergreen/save.html)

--- a/tests/PublicFunctions.Tests.ps1
+++ b/tests/PublicFunctions.Tests.ps1
@@ -33,7 +33,19 @@ Describe -Tag "Get" -Name "Get-EvergreenApp <application>" -ForEach $Application
             $Output | Should -BeOfType "PSCustomObject"
         }
 
-        # Test that output with Version property includes numbers and "." only
+        # Test that the output has a Version property and that property is a string
+        It "<application>: should have a Version property that is a string" {
+            If ([System.Boolean]($Output[0].PSObject.Properties.name -match "Version")) {
+                ForEach ($object in $Output) {
+                    $object.Version | Should -BeOfType [System.String]
+                }
+            }
+            Else {
+                Write-Host -ForegroundColor Yellow "`t<application> does not have a Version property."
+            }
+        }
+
+        # Test that output with Version property is valid
         It "<application>: should have a valid version number" {
             If ([System.Boolean]($Output[0].PSObject.Properties.name -match "Version")) {
                 ForEach ($object in $Output) {
@@ -44,6 +56,13 @@ Describe -Tag "Get" -Name "Get-EvergreenApp <application>" -ForEach $Application
             }
             Else {
                 Write-Host -ForegroundColor Yellow "`t<application> does not have a Version property."
+            }
+        }
+
+        # Test that the output has a URI property and that property is a string
+        It "<application>: should have a URI property that is a string" {
+            ForEach ($object in $Output) {
+                $object.URI | Should -BeOfType [System.String]
             }
         }
     }


### PR DESCRIPTION
* Update `VMwareHorizonClient` with additional filtering to select the latest version correctly to fix #161
* Add internal function `Save-File` to download a URL with `Invoke-WebRequest` and return the downloaded file path
* Update internal application functions for consistent use of `Resolve-SystemNetWebRequest` to fix #174 - `Get-FoxitReader`, `Get-LogMeInGoToOpener`, `Get-MicrosoftSsms`, `Get-MicrosoftVisualStudio`, `Get-RingCentral`, `Get-Slack`
* Update references to documentation site `https://stealthpuppy.com/Evergreen` to `https://stealthpuppy.com/evergreen`