### PR TITLE
Add files via upload

### DIFF
--- a/Evergreen/Manifests/VeraCrypt.json
+++ b/Evergreen/Manifests/VeraCrypt.json
@@ -18,7 +18,7 @@
             "ContentType": "application/rss+xml; charset=utf-8",
             "Uri": "https://nchc.dl.sourceforge.net/project/veracrypt"
         },
-        "MatchVersion": "(\\d+(\\.\\d+){1,3})",
+        "MatchVersion": "(\\d+(\\.\\d.+([^/]+)){1,3})",
         "DatePattern": "yyyy-MM-dd HH:mm:ss"
     },
     "Install": {


### PR DESCRIPTION
Fix issue where wrong version number was returned. My regex is at a beginner level but it does seem to work.

```
PS C:\Users\Ashley.How> get-evergreenapp veracrypt

Version      Architecture Type URI
-------      ------------ ---- ---
1.24-Update7 x86          exe  https://nchc.dl.sourceforge.net/project/veracrypt/VeraCrypt%201.24-Update7/VeraCrypt%...
1.24-Update7 x86          exe  https://nchc.dl.sourceforge.net/project/veracrypt/VeraCrypt%201.24-Update7/VeraCrypt%...
1.24-Update7 x86          exe  https://nchc.dl.sourceforge.net/project/veracrypt/VeraCrypt%201.24-Update7/VeraCrypt%...
1.24-Update7 x86          exe  https://nchc.dl.sourceforge.net/project/veracrypt/VeraCrypt%201.24-Update7/VeraCrypt%...
```

