### PR TITLE
Add BlueJ, Tableau Destkop

### DIFF
--- a/Evergreen/Apps/Get-BlueJ.ps1
+++ b/Evergreen/Apps/Get-BlueJ.ps1
@@ -30,17 +30,31 @@ Function Get-BlueJ {
 
     If ($Null -ne $Content) {
 
-        # Convert from UTF8
-        $Updates = [System.Text.Encoding]::UTF8.GetString($Content)
+        # Convert response from UTF8
+        Try { 
+            $Updates = [System.Text.Encoding]::UTF8.GetString($Content)
+        }
+        Catch {
+            Throw "$($MyInvocation.MyCommand): failed to convert feed into to UTF8."
+        }
 
         # Latest version is stored at the top of the file on its own line
         $LatestVersion = $Updates.Split([Environment]::NewLine)[0]
 
+        # Validate that what we obtained above is actually a version in SemVer format
+        Try {
+            $Version = [RegEx]::Match($LatestVersion, $res.Get.MatchVersion).Captures.Groups[0].Value
+        }
+        Catch {
+            Throw "$($MyInvocation.MyCommand): failed to obtain latest version."
+        }
+
         # Construct the output; Return the custom object to the pipeline
         $PSObject = [PSCustomObject] @{
-            Version = $LatestVersion
-            URI     = $res.Get.DownloadUri -replace $res.Get.ReplaceText, ($LatestVersion.Replace(".", ""))
+            Version = $Version
+            URI     = $res.Get.DownloadUri -replace $res.Get.ReplaceText, ($Version.Replace(".", ""))
         }
         Write-Output -InputObject $PSObject
+
     }
 }

--- a/Evergreen/Apps/Get-BlueJ.ps1
+++ b/Evergreen/Apps/Get-BlueJ.ps1
@@ -1,0 +1,46 @@
+Function Get-BlueJ {
+    <#
+        .SYNOPSIS
+            Get the current version and download URIs for the supported releases of BlueJ.
+
+        .NOTES
+            Author: Andrew Cooper
+            Twitter: @adotcoop
+    #>
+    [OutputType([System.Management.Automation.PSObject])]
+    [CmdletBinding(SupportsShouldProcess = $False)]
+    param (
+        [Parameter(Mandatory = $False, Position = 0)]
+        [ValidateNotNull()]
+        [System.Management.Automation.PSObject]
+        $res = (Get-FunctionResource -AppName ("$($MyInvocation.MyCommand)".Split("-"))[1]),
+
+        [Parameter(Mandatory = $False, Position = 1)]
+        [ValidateNotNull()]
+        [System.String] $Filter
+    )
+
+    # Query the BlueJ update API
+    $iwcParams = @{
+        Uri       = $res.Get.Uri
+        UserAgent = $res.Get.UserAgent
+    }
+
+    $Content = Invoke-WebRequestWrapper @iwcParams
+
+    If ($Null -ne $Content) {
+
+        # Convert from UTF8
+        $Updates = [System.Text.Encoding]::UTF8.GetString($Content)
+
+        # Latest version is stored at the top of the file on its own line
+        $LatestVersion = $Updates.Split([Environment]::NewLine)[0]
+
+        # Construct the output; Return the custom object to the pipeline
+        $PSObject = [PSCustomObject] @{
+            Version = $LatestVersion
+            URI     = $res.Get.DownloadUri -replace $res.Get.ReplaceText, ($LatestVersion.Replace(".", ""))
+        }
+        Write-Output -InputObject $PSObject
+    }
+}

--- a/Evergreen/Apps/Get-Postman.ps1
+++ b/Evergreen/Apps/Get-Postman.ps1
@@ -1,0 +1,50 @@
+Function Get-Postman {
+    <#
+        .SYNOPSIS
+            Get the current version and download URIs for Postman.
+
+        .NOTES
+            Author: Andrew Cooper
+            Twitter: @adotcoop
+    #>
+    [OutputType([System.Management.Automation.PSObject])]
+    [CmdletBinding(SupportsShouldProcess = $False)]
+    param (
+        [Parameter(Mandatory = $False, Position = 0)]
+        [ValidateNotNull()]
+        [System.Management.Automation.PSObject]
+        $res = (Get-FunctionResource -AppName ("$($MyInvocation.MyCommand)".Split("-"))[1]),
+
+        [Parameter(Mandatory = $False, Position = 1)]
+        [ValidateNotNull()]
+        [System.String] $Filter
+    )
+
+    # Query the Postman update API
+    $params = @{
+        Uri         = $res.Get.Uri
+        ContentType = "application/octet-stream"
+    }
+
+    $Content = Invoke-RestMethodWrapper @params
+
+    If ($Null -ne $Content) {
+
+        # Work out latest version
+        $LatestVersion = $Content.changelog | `
+            Sort-Object -Property @{ Expression = { [System.Version]$_.name }; Descending = $true } | `
+            Select-Object -First 1
+
+        # Construct the output; Return the custom object to the pipeline
+        $PSObject = [PSCustomObject] @{
+            Version  = $LatestVersion.name
+            Size     = $LatestVersion.assets.size
+            Hash     = $LatestVersion.assets.hash
+            Date     = ConvertTo-DateTime -DateTime ($LatestVersion.createdAt) -Pattern $res.Get.DatePattern 
+            Filename = $LatestVersion.assets.name
+            URI      = $LatestVersion.assets.url
+        }
+        Write-Output -InputObject $PSObject
+        
+    }
+}

--- a/Evergreen/Apps/Get-TableauDesktop.ps1
+++ b/Evergreen/Apps/Get-TableauDesktop.ps1
@@ -1,0 +1,69 @@
+Function Get-TableauDesktop {
+    <#
+        .SYNOPSIS
+            Get the current version and download URIs for the supported releases of Tableau Desktop.
+
+        .NOTES
+            Author: Andrew Cooper
+            Twitter: @adotcoop
+    #>
+    [OutputType([System.Management.Automation.PSObject])]
+    [CmdletBinding(SupportsShouldProcess = $False)]
+    param (
+        [Parameter(Mandatory = $False, Position = 0)]
+        [ValidateNotNull()]
+        [System.Management.Automation.PSObject]
+        $res = (Get-FunctionResource -AppName ("$($MyInvocation.MyCommand)".Split("-"))[1]),
+
+        [Parameter(Mandatory = $False, Position = 1)]
+        [ValidateNotNull()]
+        [System.String] $Filter
+    )
+
+    # Query the Tableau update API
+    $iwcParams = @{
+        Uri       = $res.Get.Uri
+        UserAgent = $res.Get.UserAgent
+    }
+
+    $Content = Invoke-WebRequestWrapper @iwcParams
+
+    If ($Null -ne $Content) {
+
+        # Convert the content to XML to grab the version number
+        Try {
+            [System.XML.XMLDocument] $xmlDocument = $Content
+        }
+        Catch [System.Exception] {
+            Write-Warning -Message "$($MyInvocation.MyCommand): failed to convert feed into an XML object."
+        }
+
+        # Work out latest version
+        $LatestVersion = $xmlDocument.versions.version | `
+            Sort-Object -Property @{ Expression = { [System.Version]$_.name }; Descending = $true } | `
+            Select-Object -First 1
+
+        ForEach ($file in ($LatestVersion.Installer | Where-Object { $_.name -match $res.Get.MatchExtensions })) {
+
+            # Attempt to work out Tableau type based on filename
+            try {
+
+                $Type = [RegEx]::Match($file.Name, $res.Get.MatchType).Captures.Groups[1].Value
+            }
+            catch {
+                $Type = $file.Name
+            }
+            
+            # Construct the output; Return the custom object to the pipeline
+            $PSObject = [PSCustomObject] @{
+                Version      = $LatestVersion.name
+                Type         = $Type
+                Architecture = Get-Architecture $file.Name
+                Hash         = $file.hash
+                HashAlg      = $LatestVersion.hashAlg
+                URI          = $("$($res.Get.DownloadUri)/$($LatestVersion.latestVersionPath)/$($file.Name)")
+            }
+            Write-Output -InputObject $PSObject
+        }
+    }
+}

--- a/Evergreen/Manifests/BlueJ.json
+++ b/Evergreen/Manifests/BlueJ.json
@@ -1,0 +1,21 @@
+{
+	"Name": "BlueJ",
+	"Source": "https://www.bluej.org/",
+	"Get": {
+		"Uri": "http://www.bluej.org/version.info",
+		"UserAgent": "Java/11.0.2",
+		"DownloadUri": "https://www.bluej.org/download/files/BlueJ-windows-#version.msi",
+		"ReplaceText": "#version"
+	},
+	"Install": {
+		"Setup": "BlueJ-windows-*.exe",
+		"Physical": {
+			"Arguments": "/install /passive /norestart",
+			"PostInstall": []
+		},
+		"Virtual": {
+			"Arguments": "/install /passive /norestart",
+			"PostInstall": []
+		}
+	}
+}

--- a/Evergreen/Manifests/BlueJ.json
+++ b/Evergreen/Manifests/BlueJ.json
@@ -5,16 +5,17 @@
 		"Uri": "http://www.bluej.org/version.info",
 		"UserAgent": "Java/11.0.2",
 		"DownloadUri": "https://www.bluej.org/download/files/BlueJ-windows-#version.msi",
-		"ReplaceText": "#version"
+		"ReplaceText": "#version",
+		"MatchVersion": "(\\d+(\\.\\d+){1,4})"
 	},
 	"Install": {
-		"Setup": "BlueJ-windows-*.exe",
+		"Setup": "BlueJ-windows-*.msi",
 		"Physical": {
-			"Arguments": "/install /passive /norestart",
+			"Arguments": "/quiet /norestart",
 			"PostInstall": []
 		},
 		"Virtual": {
-			"Arguments": "/install /passive /norestart",
+			"Arguments": "/quiet /norestart",
 			"PostInstall": []
 		}
 	}

--- a/Evergreen/Manifests/Postman.json
+++ b/Evergreen/Manifests/Postman.json
@@ -1,0 +1,19 @@
+{
+	"Name": "Postman",
+	"Source": "https://www.getpostman.com/",
+	"Get": {
+		"Uri": "https://dl.pstmn.io/changelog?channel=stable&platform=win64",
+		"DatePattern": "yyyy-MM-ddTHH:mm:ss.fffK"
+	},
+	"Install": {
+		"Setup": "Postman*.exe",
+		"Physical": {
+			"Arguments": "",
+			"PostInstall": []
+		},
+		"Virtual": {
+			"Arguments": "",
+			"PostInstall": []
+		}
+	}
+}

--- a/Evergreen/Manifests/TableauDesktop.json
+++ b/Evergreen/Manifests/TableauDesktop.json
@@ -1,0 +1,22 @@
+{
+	"Name": "Tableau Desktop",
+	"Source": "https://www.tableau.com/",
+	"Get": {
+		"Uri": "https://downloads.tableau.com/TableauAutoUpdate.xml",
+		"UserAgent": "Tableau Desktop 20203.20.0801.1333; pro; libcurl-client; 64-bit; en_US; Microsoft Windows 10 Enterprise (Build 19042);",
+		"DownloadUri": "https://downloads.tableau.com",
+		"MatchExtensions": "\\.exe$",
+		"MatchType": "Tableau(.*)-64"
+	},
+	"Install": {
+		"Setup": "TableauDesktop*.exe",
+		"Physical": {
+			"Arguments": "/quiet /norestart",
+			"PostInstall": []
+		},
+		"Virtual": {
+			"Arguments": "/quiet /norestart",
+			"PostInstall": []
+		}
+	}
+}


### PR DESCRIPTION
##  Add BlueJ and Tableau Desktop

Both of these apps had their autoupdate download api discovered using fiddler. 

BlueJ looks up a text file called version.info. At the head of the file is the version number, then there is some text below containing details of what the update contains. Get-BlueJ.ps1 creates a url by inserting the version number  from this text file into a standard download uri as used on the website. This uri format has not changed since version 4.0.0 released in 2017 so should hopefully be pretty stable.

Incidentally, to get the BlueJ to use the fiddler proxy requires editing a line in `C:\Program Files\BlueJ\lib\bluej.defs` so that it reads

`bluej.windows.vm.args=-Djavafx.embed.singleThread=true -Dhttp.proxyHost=127.0.0.1 -Dhttp.proxyPort=8888`

Tableau Desktop obtains an xml file containing a large number of different versions. The code parses this looking for the latest version and then extracts the correct url from the xml. The feed has previously contained different types of Tableau such as Tableau Reader and Tableau Public, so there is an additional field added to the output object using `"MatchType": "Tableau(.*)-64"` to capture the Tableau application type in case the feed is used for these variants again in future. 