### PR TITLE
Add 5 Apps and modification to Tableau Desktop

### DIFF
--- a/Evergreen/Apps/Get-FreedomScientificFusion.ps1
+++ b/Evergreen/Apps/Get-FreedomScientificFusion.ps1
@@ -1,0 +1,64 @@
+Function Get-FreedomScientificFusion {
+    <#
+        .SYNOPSIS
+            Get the current version and download URL for Freedom Scientific Fusion.
+
+        .NOTES
+            Author: Andrew Cooper
+            Twitter: @adotcoop
+    #>
+    [OutputType([System.Management.Automation.PSObject])]
+    [CmdletBinding(SupportsShouldProcess = $False)]
+    param (
+        [Parameter(Mandatory = $False, Position = 0)]
+        [ValidateNotNull()]
+        [System.Management.Automation.PSObject]
+        $res = (Get-FunctionResource -AppName ("$($MyInvocation.MyCommand)".Split("-"))[1]),
+
+        [Parameter(Mandatory = $False, Position = 1)]
+        [ValidateNotNull()]
+        [System.String] $Filter
+    )
+    
+    # The URI feeds require a unix timestamp as a parameter
+    $UnixTimestamp = [int64](([DateTime]::UtcNow) - ([DateTime]'1970-01-01Z')).TotalSeconds
+
+    # Query the API to get the list of major versions
+    $MajorVersionsURI = $res.Get.Update.Uri -replace $res.Get.Update.ReplaceTimestamp, $UnixTimestamp
+    $MajorVersions = Invoke-RestMethodWrapper $MajorVersionsURI
+
+    # Get latest version
+    $LatestVersion = $MajorVersions | Sort-Object -Property { [Int] $_.MajorVersion } -Descending | Select-Object -First 1
+    Write-Verbose "$($MyInvocation.MyCommand): Latest version is $LatestVersion"
+
+    # Query the API to get the list of releases
+    $DownloadFeedURI = ($res.Get.Download.Uri -replace $res.Get.Download.ReplaceMajorVersion, $LatestVersion.MajorVersion ) -replace $res.Get.Update.ReplaceTimestamp, $UnixTimestamp
+
+    $downloadFeed = Invoke-RestMethodWrapper $DownloadFeedURI 
+
+    If ($Null -ne $downloadFeed) {
+                
+        ForEach ($Release in $downloadFeed) {
+
+            # Extract the version information 
+            try {
+                $Version = [RegEx]::Match($Release.FileName, $res.Get.Download.MatchVersion).Captures.Groups[1].Value 
+            }
+            catch {
+                Throw "$($MyInvocation.MyCommand): Failed to extract the version information from the uri."
+            }
+  
+            # Construct the output; Return the custom object to the pipeline
+            $PSObject = [PSCustomObject] @{
+                Version = $Version
+                Date    = ConvertTo-DateTime -DateTime $Release.ReleaseDate -Pattern $res.Get.Download.DatePattern
+                URI     = $Release.InstallerLocationHTTP
+            }
+            Write-Output -InputObject $PSObject
+        }
+    }       
+    Else {
+        Throw "$($MyInvocation.MyCommand): Failed to obtain latest releases for version $($LatestVersion.ProductMajor)."      
+    }
+    
+}

--- a/Evergreen/Apps/Get-FreedomScientificJAWS.ps1
+++ b/Evergreen/Apps/Get-FreedomScientificJAWS.ps1
@@ -1,0 +1,65 @@
+Function Get-FreedomScientificJAWS {
+    <#
+        .SYNOPSIS
+            Get the current version and download URL for Freedom Scientific JAWS.
+
+        .NOTES
+            Author: Andrew Cooper
+            Twitter: @adotcoop
+    #>
+    [OutputType([System.Management.Automation.PSObject])]
+    [CmdletBinding(SupportsShouldProcess = $False)]
+    param (
+        [Parameter(Mandatory = $False, Position = 0)]
+        [ValidateNotNull()]
+        [System.Management.Automation.PSObject]
+        $res = (Get-FunctionResource -AppName ("$($MyInvocation.MyCommand)".Split("-"))[1]),
+
+        [Parameter(Mandatory = $False, Position = 1)]
+        [ValidateNotNull()]
+        [System.String] $Filter
+    )
+    
+    # The URI feeds require a unix timestamp as a parameter
+    $UnixTimestamp = [int64](([DateTime]::UtcNow) - ([DateTime]'1970-01-01Z')).TotalSeconds
+
+    # Query the API to get the list of major versions
+    $MajorVersionsURI = $res.Get.Update.Uri -replace $res.Get.Update.ReplaceTimestamp, $UnixTimestamp
+    $MajorVersions = Invoke-RestMethodWrapper $MajorVersionsURI
+
+    # Get latest version
+    $LatestVersion = $MajorVersions | Sort-Object -Property { [Int] $_.MajorVersion } -Descending | Select-Object -First 1
+    Write-Verbose "$($MyInvocation.MyCommand): Latest version is $LatestVersion"
+
+    # Query the API to get the list of releases
+    $DownloadFeedURI = ($res.Get.Download.Uri -replace $res.Get.Download.ReplaceMajorVersion, $LatestVersion.MajorVersion ) -replace $res.Get.Update.ReplaceTimestamp, $UnixTimestamp
+
+    $downloadFeed = Invoke-RestMethodWrapper $DownloadFeedURI 
+
+    If ($Null -ne $downloadFeed) {
+                
+        ForEach ($Release in $downloadFeed) {
+
+            # Extract the version information 
+            try {
+                $Version = [RegEx]::Match($Release.FileName, $res.Get.Download.MatchVersion).Captures.Groups[1].Value 
+            }
+            catch {
+                Throw "$($MyInvocation.MyCommand): Failed to extract the version information from the uri."
+            }
+  
+            # Construct the output; Return the custom object to the pipeline
+            $PSObject = [PSCustomObject] @{
+                Version      = $Version
+                Architecture = Get-Architecture $Release.InstallerPlatform
+                Date         = ConvertTo-DateTime -DateTime $Release.ReleaseDate -Pattern $res.Get.Download.DatePattern
+                URI          = $Release.InstallerLocationHTTP
+            }
+            Write-Output -InputObject $PSObject
+        }
+    }       
+    Else {
+        Throw "$($MyInvocation.MyCommand): Failed to obtain latest releases for version $($LatestVersion.ProductMajor)."      
+    }
+    
+}

--- a/Evergreen/Apps/Get-FreedomScientificZoomText.ps1
+++ b/Evergreen/Apps/Get-FreedomScientificZoomText.ps1
@@ -1,0 +1,64 @@
+Function Get-FreedomScientificZoomText {
+    <#
+        .SYNOPSIS
+            Get the current version and download URL for Freedom Scientific ZoomText.
+
+        .NOTES
+            Author: Andrew Cooper
+            Twitter: @adotcoop
+    #>
+    [OutputType([System.Management.Automation.PSObject])]
+    [CmdletBinding(SupportsShouldProcess = $False)]
+    param (
+        [Parameter(Mandatory = $False, Position = 0)]
+        [ValidateNotNull()]
+        [System.Management.Automation.PSObject]
+        $res = (Get-FunctionResource -AppName ("$($MyInvocation.MyCommand)".Split("-"))[1]),
+
+        [Parameter(Mandatory = $False, Position = 1)]
+        [ValidateNotNull()]
+        [System.String] $Filter
+    )
+    
+    # The URI feeds require a unix timestamp as a parameter
+    $UnixTimestamp = [int64](([DateTime]::UtcNow) - ([DateTime]'1970-01-01Z')).TotalSeconds
+
+    # Query the API to get the list of major versions
+    $MajorVersionsURI = $res.Get.Update.Uri -replace $res.Get.Update.ReplaceTimestamp, $UnixTimestamp
+    $MajorVersions = Invoke-RestMethodWrapper $MajorVersionsURI
+
+    # Get latest version
+    $LatestVersion = $MajorVersions | Sort-Object -Property { [Int] $_.MajorVersion } -Descending | Select-Object -First 1
+    Write-Verbose "$($MyInvocation.MyCommand): Latest version is $LatestVersion"
+
+    # Query the API to get the list of releases
+    $DownloadFeedURI = ($res.Get.Download.Uri -replace $res.Get.Download.ReplaceMajorVersion, $LatestVersion.MajorVersion ) -replace $res.Get.Update.ReplaceTimestamp, $UnixTimestamp
+    Write-Verbose "$($MyInvocation.MyCommand): Built $DownloadFeedURI"
+    $downloadFeed = Invoke-RestMethodWrapper $DownloadFeedURI 
+
+    If ($Null -ne $downloadFeed) {
+                
+        ForEach ($Release in $downloadFeed) {
+
+            # Extract the version information 
+            try {
+                $Version = [RegEx]::Match($Release.FileName, $res.Get.Download.MatchVersion).Captures.Groups[1].Value 
+            }
+            catch {
+                Throw "$($MyInvocation.MyCommand): Failed to extract the version information from the uri."
+            }
+  
+            # Construct the output; Return the custom object to the pipeline
+            $PSObject = [PSCustomObject] @{
+                Version = $Version
+                Date    = ConvertTo-DateTime -DateTime $Release.ReleaseDate -Pattern $res.Get.Download.DatePattern
+                URI     = $Release.InstallerLocationHTTP
+            }
+            Write-Output -InputObject $PSObject
+        }
+    }       
+    Else {
+        Throw "$($MyInvocation.MyCommand): Failed to obtain latest releases for version $($LatestVersion.ProductMajor)."      
+    }
+    
+}

--- a/Evergreen/Apps/Get-MestrelabMnova.ps1
+++ b/Evergreen/Apps/Get-MestrelabMnova.ps1
@@ -1,0 +1,51 @@
+Function Get-MestrelabMnova {
+    <#
+        .SYNOPSIS
+            Get the current version and download URL for Mestrelab MNova.
+
+        .NOTES
+            Author: Andrew Cooper
+            Twitter: @adotcoop
+    #>
+    [OutputType([System.Management.Automation.PSObject])]
+    [CmdletBinding(SupportsShouldProcess = $False)]
+    param (
+        [Parameter(Mandatory = $False, Position = 0)]
+        [ValidateNotNull()]
+        [System.Management.Automation.PSObject]
+        $res = (Get-FunctionResource -AppName ("$($MyInvocation.MyCommand)".Split("-"))[1]),
+
+        [Parameter(Mandatory = $False, Position = 1)]
+        [ValidateNotNull()]
+        [System.String] $Filter
+    )
+
+    # Query the repo to get the full list of files
+    $updateFeed = Invoke-RestMethodWrapper -Uri $res.Get.Update.Uri 
+
+    If ($Null -ne $updateFeed) {
+       
+        # Grab the Windows files
+        Try {
+            $windowsReleases = $updateFeed.Products.Product | Where-Object { $_.Platform -match $res.Get.Platform }
+        }
+        Catch {
+            Throw "$($MyInvocation.MyCommand): Failed to extract windows versions"
+        }
+
+        # Build the output object for each release
+        ForEach ($Release in $windowsReleases) {
+            # Construct the output; Return the custom object to the pipeline
+            $PSObject = [PSCustomObject] @{
+                Version      = $Release.Version
+                Revision     = $Release.Revision
+                Architecture = Get-Architecture $Release.Architecture
+                URI          = $Release.URL
+            }
+            Write-Output -InputObject $PSObject
+        }
+    }
+    Else {
+        Write-Warning -Message "$($MyInvocation.MyCommand): unable to retrieve content from $($res.Get.Update.Uri)."
+    }
+}

--- a/Evergreen/Apps/Get-jrsoftwareInnoSetup.ps1
+++ b/Evergreen/Apps/Get-jrsoftwareInnoSetup.ps1
@@ -1,7 +1,7 @@
-Function Get-TableauDesktop {
+Function Get-jrsoftwareInnoSetup {
     <#
         .SYNOPSIS
-            Get the current version and download URL for Tableau Desktop.
+            Get the current version and download URL for jrsoftware InnoSetup.
 
         .NOTES
             Author: Andrew Cooper
@@ -36,7 +36,7 @@ Function Get-TableauDesktop {
 
         # Construct the output; Return the custom object to the pipeline
         $PSObject = [PSCustomObject] @{
-            Version = $Version.Replace('-', '.')
+            Version = $Version
             URI     = $Response.ResponseUri.AbsoluteUri
         }
         Write-Output -InputObject $PSObject

--- a/Evergreen/Manifests/FreedomScientificFusion.json
+++ b/Evergreen/Manifests/FreedomScientificFusion.json
@@ -1,0 +1,27 @@
+{
+	"Name": "Freedom Scientific Fusion",
+	"Source": "https://www.freedomscientific.com/products/software/fusion/",
+	"Get": {
+		"Update": {
+			"Uri": "https://support.freedomscientific.com/Downloads/OfflineInstallers/GetVersionsWithOfflineInstallers?product=Fusion&_=#timestamp",
+			"ReplaceTimestamp" : "#timestamp"
+		},
+		"Download": {
+			"Uri": "https://support.freedomscientific.com/Downloads/OfflineInstallers/GetInstallers?product=Fusion&version=#majorversion&language=mul&releaseType=Offline&_=#timestamp",
+			"ReplaceMajorVersion" : "#majorversion",
+			"MatchVersion": "(\\d+(\\.\\d+){1,4})",
+			"DatePattern": "Y"
+		}
+	},
+	"Install": {
+		"Setup": "",
+		"Physical": {
+			"Arguments": "",
+			"PostInstall": []
+		},
+		"Virtual": {
+			"Arguments": "",
+			"PostInstall": []
+		}
+	}
+}

--- a/Evergreen/Manifests/FreedomScientificJAWS.json
+++ b/Evergreen/Manifests/FreedomScientificJAWS.json
@@ -1,0 +1,27 @@
+{
+	"Name": "Freedom Scientific JAWS",
+	"Source": "https://www.freedomscientific.com/products/software/jaws/",
+	"Get": {
+		"Update": {
+			"Uri": "https://support.freedomscientific.com/Downloads/OfflineInstallers/GetVersionsWithOfflineInstallers?product=JAWS&_=#timestamp",
+			"ReplaceTimestamp" : "#timestamp"
+		},
+		"Download": {
+			"Uri": "https://support.freedomscientific.com/Downloads/OfflineInstallers/GetInstallers?product=JAWS&version=#majorversion&language=mul&releaseType=Offline&_=#timestamp",
+			"ReplaceMajorVersion" : "#majorversion",
+			"MatchVersion": "(\\d+(\\.\\d+){1,4})",
+			"DatePattern": "Y"
+		}
+	},
+	"Install": {
+		"Setup": "",
+		"Physical": {
+			"Arguments": "",
+			"PostInstall": []
+		},
+		"Virtual": {
+			"Arguments": "",
+			"PostInstall": []
+		}
+	}
+}

--- a/Evergreen/Manifests/FreedomScientificZoomText.json
+++ b/Evergreen/Manifests/FreedomScientificZoomText.json
@@ -1,0 +1,27 @@
+{
+	"Name": "Freedom Scientific ZoomText",
+	"Source": "https://www.freedomscientific.com/products/software/zoomtext/",
+	"Get": {
+		"Update": {
+			"Uri": "https://support.freedomscientific.com/Downloads/OfflineInstallers/GetVersionsWithOfflineInstallers?product=ZoomText&_=#timestamp",
+			"ReplaceTimestamp" : "#timestamp"
+		},
+		"Download": {
+			"Uri": "https://support.freedomscientific.com/Downloads/OfflineInstallers/GetInstallers?product=ZoomText&version=#majorversion&language=enu&releaseType=Offline&_=#timestamp",
+			"ReplaceMajorVersion" : "#majorversion",
+			"MatchVersion": "(\\d+(\\.\\d+){1,4})",
+			"DatePattern": "Y"
+		}
+	},
+	"Install": {
+		"Setup": "",
+		"Physical": {
+			"Arguments": "",
+			"PostInstall": []
+		},
+		"Virtual": {
+			"Arguments": "",
+			"PostInstall": []
+		}
+	}
+}

--- a/Evergreen/Manifests/MestrelabMnova.json
+++ b/Evergreen/Manifests/MestrelabMnova.json
@@ -1,0 +1,22 @@
+{
+	"Name": "Mestrelab Mnova",
+	"Source": "https://mestrelab.com/software/mnova/",
+	"Get": {
+		"Update": {
+			"Uri": "https://mestrelab.com/auto-upgrade-mnova/"
+		},
+		"MatchVersion": "(\\d+(\\.\\d+){1,3})",
+		"Platform": "Windows"
+	},
+	"Install": {
+		"Setup": "MestReNova-*.exe",
+		"Physical": {
+			"Arguments": "/quiet /noreboot INSTALL_DESKTOP_SHORTCUT=0",
+			"PostInstall": []
+		},
+		"Virtual": {
+			"Arguments": "/quiet /noreboot INSTALL_DESKTOP_SHORTCUT=0",
+			"PostInstall": []
+		}
+	}
+}

--- a/Evergreen/Manifests/TableauDesktop.json
+++ b/Evergreen/Manifests/TableauDesktop.json
@@ -1,27 +1,25 @@
 {
-    "Name": "Tableau Desktop",
-    "Source": "https://www.tableau.com/",
-    "Get": {
-        "Update": {
-            "Uri": "https://downloads.tableau.com/TableauAutoUpdate.xml",
-            "UserAgent": "Tableau Desktop 20203.20.0801.1333; pro; libcurl-client; 64-bit; en_US; Microsoft Windows 10 Enterprise (Build 19042);",
-            "ContentType": "application/xml; charset=utf-8",
-			"MatchExtensions": "\\.exe$",
-            "MatchType": "Tableau(.*)-64"
-        },
-        "Download": {
-            "Uri": "https://downloads.tableau.com"
-        }
-    },
-    "Install": {
-        "Setup": "TableauDesktop*.exe",
-        "Physical": {
-            "Arguments": "/quiet /norestart",
-            "PostInstall": []
-        },
-        "Virtual": {
-            "Arguments": "/quiet /norestart",
-            "PostInstall": []
-        }
-    }
+	"Name": "Tableau Desktop",
+	"Source": "https://www.tableau.com/",
+	"Get": {
+		"Update": {
+			"Uri": ""
+		},
+		"Download": {
+			"Uri": "https://www.tableau.com/downloads/desktop/pc64",
+			"Property": "ResponseUri.Headers.Location",
+			"MatchVersion": "(\\d+(\\-\\d+){1,3})"
+		}
+	},
+	"Install": {
+		"Setup": "TableauDesktop*.exe",
+		"Physical": {
+			"Arguments": "/quiet /norestart",
+			"PostInstall": []
+		},
+		"Virtual": {
+			"Arguments": "/quiet /norestart",
+			"PostInstall": []
+		}
+	}
 }

--- a/Evergreen/Manifests/jrsoftwareInnoSetup.json
+++ b/Evergreen/Manifests/jrsoftwareInnoSetup.json
@@ -1,0 +1,25 @@
+{
+	"Name": "jrsoftware InnoSetup",
+	"Source": "https://www.innosetup.com",
+	"Get": {
+		"Update": {
+			"Uri": ""
+		},
+		"Download": {
+			"Uri": "https://jrsoftware.org/download.php/is.exe",
+			"Property": "ResponseUri.Headers.Location",
+			"MatchVersion": "(\\d+(\\.\\d+){1,3})"
+		}
+	},
+	"Install": {
+		"Setup": "innosetup*.exe",
+		"Physical": {
+			"Arguments": "/VERYSILENT",
+			"PostInstall": []
+		},
+		"Virtual": {
+			"Arguments": "/VERYSILENT",
+			"PostInstall": []
+		}
+	}
+}


### PR DESCRIPTION
# Added 5 apps and modified Tableau Desktop to be more reliable 

- Website API based: Freedom Scientific Fusion, Freedom Scientific JAWS, Freedom Scientific ZoomText
- Autoupdate based: Mestrelab Mnova
- Download redirect: jrsoftware InnoSetup

The Freedom Scientific json requests can be seen on the offline installer download page https://support.freedomscientific.com/Downloads/OfflineInstallers 

Mnova was discovered using Strings on the application executable.

### Tableau Desktop (breaking change)
Previously this used the autoupdate API as used by the app itself. This has been out of date for a while, as pointed out by @DanGough in the comments of this pull request https://github.com/aaronparker/evergreen/pull/203#issuecomment-878075848 

This change uses the same download redirect method as Tableau Prep and Tableau Reader. It provides consistency across all the Evergreen functions for this vendor but is a possible breaking change if you rely on the properties `Type, Architecture, Hash, HashAlg` as they can't be obtained via the redirect. However, since the older function returns only one result, it's unlikely anyone should be using any of these properties to filter the results.

The previous version of Get-TableauDesktop returns the following
![image](https://user-images.githubusercontent.com/67840206/126362506-7b4b3597-ce64-4276-9588-5d57bacdb877.png)
The new version only returns the Version and URI
![image](https://user-images.githubusercontent.com/67840206/126362623-ed92235e-88fc-4f6a-9087-0dc7b6b1fa69.png)

I did think of keeping the `Architecture` property to lessen the impact of the change, but thought it better to keep consistency with the other apps from that vendor instead

![image](https://user-images.githubusercontent.com/67840206/126363812-b7efe776-e393-4981-af41-ee0f0c73ab80.png)

