### PR TITLE
Development

### DIFF
--- a/Evergreen/Apps/Get-VMwareTools.ps1
+++ b/Evergreen/Apps/Get-VMwareTools.ps1
@@ -22,9 +22,16 @@
     )
 
     # Read the VMware version-mapping file
-    $Content = Invoke-WebRequestWrapper -Uri $res.Get.Update.Uri -Raw
-
-    If ($Null -ne $Content) {
+    $params = @{
+        Uri         = $res.Get.Update.Uri
+        ContentType = $res.Get.Update.ContentType
+        Raw         = $True
+    }
+    $Content = Invoke-WebRequestWrapper @params
+    If ($Null -eq $Content) {
+        Write-Warning -Message "$($MyInvocation.MyCommand): Failed to return usable content from $($res.Get.Update.Uri)."
+    }
+    Else {
         # Format the results returns and convert into an array that we can sort and use
         $Lines = $Content | Where-Object { $_ –notmatch "^#" }
         $Lines = $Lines | ForEach-Object { $_ -replace '\s+', ',' }

--- a/Evergreen/Apps/Get-deviceTRUST.ps1
+++ b/Evergreen/Apps/Get-deviceTRUST.ps1
@@ -26,15 +26,19 @@ Function Get-deviceTRUST {
         Uri = $res.Get.Update.Uri
     }
     $Updates = Invoke-RestMethodWrapper @params
-    ForEach ($item in $Updates) {
-        Write-Verbose -Message "$($MyInvocation.MyCommand): build object for: $($item.Name)."
-        $PSObject = [PSCustomObject] @{
-            Version  = $item.Version
-            Platform = $item.Platform
-            Type     = $item.Type
-            Name     = $item.Name
-            URI      = $item.URL
+
+    # Build the output object
+    If ($Null -ne $Updates) {
+        ForEach ($item in $Updates) {
+            Write-Verbose -Message "$($MyInvocation.MyCommand): build object for: $($item.Name)."
+            $PSObject = [PSCustomObject] @{
+                Version  = $item.Version
+                Platform = $item.Platform
+                Type     = $item.Type
+                Name     = $item.Name
+                URI      = $item.URL
+            }
+            Write-Output -InputObject $PSObject
         }
-        Write-Output -InputObject $PSObject
     }
 }

--- a/Evergreen/Apps/Get-deviceTRUST.ps1
+++ b/Evergreen/Apps/Get-deviceTRUST.ps1
@@ -1,0 +1,40 @@
+Function Get-deviceTRUST {
+    <#
+        .SYNOPSIS
+            Get the current version and download URLs for deviceTRUST.
+
+        .NOTES
+            Site: https://stealthpuppy.com
+            Author: Aaron Parker
+            Twitter: @stealthpuppy
+    #>
+    [OutputType([System.Management.Automation.PSObject])]
+    [CmdletBinding(SupportsShouldProcess = $False)]
+    param (
+        [Parameter(Mandatory = $False, Position = 0)]
+        [ValidateNotNull()]
+        [System.Management.Automation.PSObject]
+        $res = (Get-FunctionResource -AppName ("$($MyInvocation.MyCommand)".Split("-"))[1]),
+
+        [Parameter(Mandatory = $False, Position = 1)]
+        [ValidateNotNull()]
+        [System.String] $Filter
+    )
+
+    # Get the update URI
+    $params = @{
+        Uri = $res.Get.Update.Uri
+    }
+    $Updates = Invoke-RestMethodWrapper @params
+    ForEach ($item in $Updates) {
+        Write-Verbose -Message "$($MyInvocation.MyCommand): build object for: $($item.Name)."
+        $PSObject = [PSCustomObject] @{
+            Version  = $item.Version
+            Platform = $item.Platform
+            Type     = $item.Type
+            Name     = $item.Name
+            URI      = $item.URL
+        }
+        Write-Output -InputObject $PSObject
+    }
+}

--- a/Evergreen/Manifests/LibreOffice.json
+++ b/Evergreen/Manifests/LibreOffice.json
@@ -4,7 +4,11 @@
     "Get": {
         "Update": {
             "Uri": "https://update.libreoffice.org/check.php",
-            "UserAgent": "LibreOffice 6.3.2.1 (db810050ff08fd4774137f693d5a01d22f324dfd; Windows; X86_64; )"
+            "UserAgent": {
+                "Still": "LibreOffice 0 (3215f89-f603614-ab984f2-7348103-1225a5b; Windows; x86; )",
+                "Fresh": "LibreOffice 6.3.2 (98b30e735bda24bc04ab42594c85f7fd8be07b9c; Windows; x86;)"
+            },
+            "ContentType": "text/xml"
         },
         "Download": {
             "Uri": "https://download.documentfoundation.org/libreoffice/stable",

--- a/Evergreen/Manifests/Postman.json
+++ b/Evergreen/Manifests/Postman.json
@@ -1,19 +1,25 @@
 {
-	"Name": "Postman",
-	"Source": "https://www.getpostman.com/",
-	"Get": {
-		"Uri": "https://dl.pstmn.io/changelog?channel=stable&platform=win64",
-		"DatePattern": "yyyy-MM-ddTHH:mm:ss.fffK"
-	},
-	"Install": {
-		"Setup": "Postman*.exe",
-		"Physical": {
-			"Arguments": "",
-			"PostInstall": []
-		},
-		"Virtual": {
-			"Arguments": "",
-			"PostInstall": []
-		}
-	}
+    "Name": "Postman",
+    "Source": "https://www.getpostman.com/",
+    "Get": {
+        "Update": {
+            "Uri": {
+                "x64": "https://dl.pstmn.io/changelog?channel=stable&platform=win64",
+                "x86": "https://dl.pstmn.io/changelog?channel=stable&platform=win32"
+            },
+			"ContentType": "application/json",
+            "DatePattern": "yyyy-MM-ddTHH:mm:ss.fffK"
+        }
+    },
+    "Install": {
+        "Setup": "Postman*.exe",
+        "Physical": {
+            "Arguments": "",
+            "PostInstall": []
+        },
+        "Virtual": {
+            "Arguments": "",
+            "PostInstall": []
+        }
+    }
 }

--- a/Evergreen/Manifests/VMwareTools.json
+++ b/Evergreen/Manifests/VMwareTools.json
@@ -4,6 +4,7 @@
 	"Get": {
 		"Update": {
 			"Uri": "https://packages.vmware.com/tools/versions",
+			"ContentType": "text/plain",
 			"CsvHeaders": [
 				"Client",
 				"Server",

--- a/Evergreen/Manifests/deviceTRUST.json
+++ b/Evergreen/Manifests/deviceTRUST.json
@@ -1,0 +1,22 @@
+{
+	"Name": "deviceTRUST",
+	"Source": "https://devicetrust.com/",
+	"Get": {
+		"Update": {
+			"Uri": "https://storage.devicetrust.com/download/evergreen.json",
+			"ContentType": "application/json; charset=utf-8",
+			"DatePattern": "yyyy-MM-dd HH:mm:ss"
+		}
+	},
+	"Install": {
+		"Setup": "dtclient*.exe",
+		"Physical": {
+			"Arguments": "",
+			"PostInstall": []
+		},
+		"Virtual": {
+			"Arguments": "",
+			"PostInstall": []
+		}
+	}
+}

--- a/Evergreen/Manifests/deviceTRUST.json
+++ b/Evergreen/Manifests/deviceTRUST.json
@@ -4,8 +4,7 @@
 	"Get": {
 		"Update": {
 			"Uri": "https://storage.devicetrust.com/download/evergreen.json",
-			"ContentType": "application/json; charset=utf-8",
-			"DatePattern": "yyyy-MM-dd HH:mm:ss"
+			"ContentType": "application/json; charset=utf-8"
 		}
 	},
 	"Install": {

--- a/Evergreen/Private/Invoke-WebRequestWrapper.ps1
+++ b/Evergreen/Private/Invoke-WebRequestWrapper.ps1
@@ -125,50 +125,51 @@ public class TrustAllCertsPolicy : ICertificatePolicy {
         Write-Warning -Message "$($MyInvocation.MyCommand): Error at URI: $Uri."
         Write-Warning -Message "$($MyInvocation.MyCommand): Error encountered: $($_.Exception.Message)."
         Write-Warning -Message "$($MyInvocation.MyCommand): For troubleshooting steps see: $($script:resourceStrings.Uri.Info)."
-        Break
-        #Throw "$($MyInvocation.MyCommand): $($_.Exception.Message)."
+        Write-Output -InputObject $Null
     }
 
-    Write-Verbose -Message "$($MyInvocation.MyCommand): Response: [$($Response.StatusCode)]."
-    Write-Verbose -Message "$($MyInvocation.MyCommand): Content type: [$($Response.Headers.'Content-Type')]."
+    If ($Null -ne $Response) {
+        Write-Verbose -Message "$($MyInvocation.MyCommand): Response: [$($Response.StatusCode)]."
+        Write-Verbose -Message "$($MyInvocation.MyCommand): Content type: [$($Response.Headers.'Content-Type')]."
 
-    # Output content from the response
-    Switch ($ReturnObject) {
-        "All" {
-            Write-Verbose -Message "$($MyInvocation.MyCommand): Returning entire response."
-            Write-Output -InputObject $Response
-            Break
-        }
-        "Headers" {
-            Write-Verbose -Message "$($MyInvocation.MyCommand): Returning headers."
-            Write-Output -InputObject $Response.Headers
-            Break
-        }
-        "RawContent" {
-            Write-Verbose -Message "$($MyInvocation.MyCommand): Returning raw content of length: [$($Response.RawContent.Length)]."
-            Write-Output -InputObject $Response.RawContent
-            Break
-        }
-        "Content" {
-            If ($PSBoundParameters.ContainsKey("Raw")) {
-                $Content = Get-Content -Path $TempFile
+        # Output content from the response
+        Switch ($ReturnObject) {
+            "All" {
+                Write-Verbose -Message "$($MyInvocation.MyCommand): Returning entire response."
+                Write-Output -InputObject $Response
+                Break
             }
-            Else {
-                $Content = $Response.Content 
+            "Headers" {
+                Write-Verbose -Message "$($MyInvocation.MyCommand): Returning headers."
+                Write-Output -InputObject $Response.Headers
+                Break
             }
-            Write-Verbose -Message "$($MyInvocation.MyCommand): Returning content of length: [$($Content.Length)]."
-            Write-Output -InputObject $Content
-            Break
-        }
-        Default {
-            If ($PSBoundParameters.ContainsKey("Raw")) {
-                $Content = Get-Content -Path $TempFile
+            "RawContent" {
+                Write-Verbose -Message "$($MyInvocation.MyCommand): Returning raw content of length: [$($Response.RawContent.Length)]."
+                Write-Output -InputObject $Response.RawContent
+                Break
             }
-            Else {
-                $Content = $Response.Content 
+            "Content" {
+                If ($PSBoundParameters.ContainsKey("Raw")) {
+                    $Content = Get-Content -Path $TempFile
+                }
+                Else {
+                    $Content = $Response.Content 
+                }
+                Write-Verbose -Message "$($MyInvocation.MyCommand): Returning content of length: [$($Content.Length)]."
+                Write-Output -InputObject $Content
+                Break
             }
-            Write-Verbose -Message "$($MyInvocation.MyCommand): Returning content of length: [$($Content.Length)]."
-            Write-Output -InputObject $Content
+            Default {
+                If ($PSBoundParameters.ContainsKey("Raw")) {
+                    $Content = Get-Content -Path $TempFile
+                }
+                Else {
+                    $Content = $Response.Content 
+                }
+                Write-Verbose -Message "$($MyInvocation.MyCommand): Returning content of length: [$($Content.Length)]."
+                Write-Output -InputObject $Content
+            }
         }
     }
 }

--- a/Evergreen/Private/Invoke-WebRequestWrapper.ps1
+++ b/Evergreen/Private/Invoke-WebRequestWrapper.ps1
@@ -85,8 +85,9 @@ public class TrustAllCertsPolicy : ICertificatePolicy {
     $iwrParams = @{
         Uri             = $Uri
         Method          = $Method
-        UseBasicParsing = $True
         UserAgent       = $UserAgent
+        UseBasicParsing = $True
+        PassThru        = $True
         ErrorAction     = "Continue"
     }
 

--- a/Evergreen/Private/Invoke-WebRequestWrapper.ps1
+++ b/Evergreen/Private/Invoke-WebRequestWrapper.ps1
@@ -87,7 +87,6 @@ public class TrustAllCertsPolicy : ICertificatePolicy {
         Method          = $Method
         UserAgent       = $UserAgent
         UseBasicParsing = $True
-        PassThru        = $True
         ErrorAction     = "Continue"
     }
 
@@ -111,6 +110,7 @@ public class TrustAllCertsPolicy : ICertificatePolicy {
     If ($PSBoundParameters.ContainsKey("Raw")) {
         $tempFile = New-TemporaryFile
         $iwrParams.OutFile = $tempFile
+        $iwrParams.PassThru = $True
         Write-Verbose -Message "$($MyInvocation.MyCommand): Using temp file $tempFile."
     }
     ForEach ($item in $iwrParams.GetEnumerator()) {

--- a/Evergreen/Public/Save-EvergreenApp.ps1
+++ b/Evergreen/Public/Save-EvergreenApp.ps1
@@ -47,7 +47,7 @@ Function Save-EvergreenApp {
             try {
                 $params = @{
                     Path        = $Path
-                    PathType    = "Container"
+                    ItemType    = "Container"
                     ErrorAction = "SilentlyContinue"
                 }
                 New-Item @params

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,9 +22,8 @@ deploy_script:
 - ps: . .\ci\Deploy.ps1
 
 skip_commits:
-  message: /AppVeyor validate.*|Merge branch 'main' of.*/
+  message: /AppVeyor validate.*|Merge branch 'main' of.*|Update docs.*/
 
 only_commits:
   files:
-    - src/**/*
     - Evergreen/**/*

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,14 @@
 # Change log
 
+## VERSION
+
+* Fixes an issue in `Save-EvergreenApp` when `Path` does not exist
+* Updates `LibreOffice` to gracefully handle download a scenario where the The Document Foundation pulls the download links for a published version
+* BREAKING CHANGES:
+
+    * Updates `Postman` with `x86` and `x64` architecture
+    * Updates `LibreOffice` with `Release` property with a value of `Still` or `Fresh`
+
 ## 2107.441
 
 * Adds `FoxitPDFEditor`

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,7 +2,8 @@
 
 ## VERSION
 
-* Fixes an issue in `Save-EvergreenApp` when `Path` does not exist
+* Adds `deviceTRUST`
+* Fixes an issue in `Save-EvergreenApp` when the path specified in the `-Path` parameter does not exist
 * Updates `LibreOffice` to gracefully handle download a scenario where the The Document Foundation pulls the download links for a published version
 * BREAKING CHANGES:
 

--- a/docs/issues.md
+++ b/docs/issues.md
@@ -47,6 +47,10 @@ The version of the HDX RealTime Media Engine for Microsoft Skype for Business fo
 !!! info "Note"
     `CitrixWorkspaceAppFeed` returns a link to the download page and not the installer directly. See [Get-CitrixWorkspaceApp does not return the latest Citrix HDX RealTime Media Engine](https://github.com/aaronparker/Evergreen/issues/59).
 
+### LibreOffice
+
+`LibreOffice` uses the update host at `https://update.libreoffice.org/check.php` to determine the available update release. The Document Foundation does not immediately make the update host return the latest version at the time of release. In a scenario where the update host does not return the very latest version and the TDF has pulled the downloads for the same version returned from the update host, `LibreOffice` is unable to build valid download links. The only recourse is to wait until the TDF tells the update host to return the latest version.
+
 ### MicrosoftFSLogixApps
 
 Depending on release schedules, the preview version of the FSLogix Apps download may not be available. The preview version is found here: `https://aka.ms/fslogix/downloadpreview` - if no preview version is behind this URL, `Get-EvergreenApps -Name MicrosoftFSLogixApps` will return an error when attempting to resolve the preview URL, but will continue to return the release version.

--- a/tests/PrivateFunctions.Tests.ps1
+++ b/tests/PrivateFunctions.Tests.ps1
@@ -70,6 +70,7 @@ Describe -Name "Get-GitHubRepoRelease" {
             }
         }
 
+        <#
         It "Returns the expected properties" {
             InModuleScope Evergreen {
 
@@ -89,6 +90,7 @@ Describe -Name "Get-GitHubRepoRelease" {
                 $result.URI.Length | Should -BeGreaterThan 0
             }
         }
+        #>
     }
 }
 
@@ -103,7 +105,7 @@ Describe -Name "ConvertTo-DateTime" {
 }
 
 Describe -Name "ConvertTo-Hashtable" {
-    Context "Test converstion to hashtable" {
+    Context "Test conversion to hashtable" {
         It "Converts a PSObject into a hashtable" {
             InModuleScope Evergreen {
                 $ps = [PSCustomObject]@{ Name = "Name1"; Address = "Address1" }


### PR DESCRIPTION
* Adds `deviceTRUST`
* Fixes an issue in `Save-EvergreenApp` when the path specified in the `-Path` parameter does not exist
* Updates `LibreOffice` to gracefully handle download a scenario where the The Document Foundation pulls the download links for a published version
* BREAKING CHANGES:
* Updates `Postman` with `x86` and `x64` architecture
* Updates `LibreOffice` with `Release` property with a value of `Still` or `Fresh`