### PR TITLE
Add FIREFOX_ESR_NEXT

### DIFF
--- a/Evergreen/Manifests/MozillaFirefox.json
+++ b/Evergreen/Manifests/MozillaFirefox.json
@@ -6,7 +6,8 @@
             "Uri": "https://product-details.mozilla.org/1.0/firefox_versions.json",
             "Channels": [
                 "LATEST_FIREFOX_VERSION",
-                "FIREFOX_ESR"
+                "FIREFOX_ESR",
+                "FIREFOX_ESR_NEXT"
             ]
         },
         "Download": {
@@ -18,6 +19,10 @@
                 "FIREFOX_ESR": {
                     "Exe": "https://download.mozilla.org/?product=firefox-esr-latest-ssl&os=#platform&lang=#language",
                     "Msi": "https://download.mozilla.org/?product=firefox-esr-msi-latest-ssl&os=#platform&lang=#language"
+                },
+                "FIREFOX_ESR_NEXT": {						 
+                    "Exe": "https://download.mozilla.org/?product=firefox-esr-next-latest-ssl&os=#platform&lang=#language",
+                    "Msi": "https://download.mozilla.org/?product=firefox-esr-next-msi-latest-ssl&os=#platform&lang=#language"
                 }
             },
             "Platforms": [


### PR DESCRIPTION
Hi  @aaronparker,

this PR will add the FIREFOX_ESR_NEXT channel to MozillaFirefox.

![image](https://user-images.githubusercontent.com/16019165/138317251-2c05eecd-8c08-4061-be2a-e054ad3b8c6a.png)
