### PR TITLE
Add more filetype support for GitHubRelease

### DIFF
--- a/Evergreen/Manifests/GitHubRelease.json
+++ b/Evergreen/Manifests/GitHubRelease.json
@@ -4,7 +4,7 @@
 	"Get": {
 		"Uri": "https://api.github.com/repos/atom/atom/releases/latest",
 		"MatchVersion": "(\\d+(\\.\\d+){1,4}).*",
-		"MatchFileTypes": "\\.exe$|\\.msi$"
+		"MatchFileTypes": "\\.exe$|\\.msi$|\\.msp$|\\.zip$"
 	},
 	"Install": {
 		"Setup": "",


### PR DESCRIPTION
Add more filetype support for GitHubRelease, required to grab Mozilla Firefox ADMX templates for instance