### PR TITLE
Development

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -62,6 +62,7 @@
         "Veracrypt",
         "Vercel",
         "voidtools",
+        "Wakerobin",
         "windowsdesktop",
         "Winget",
         "Wireshark",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -28,6 +28,7 @@
         "Hashicorp",
         "iainbrighton",
         "Karakun",
+        "latestversion",
         "linkid",
         "MAML",
         "Mestrelab",
@@ -63,6 +64,7 @@
         "voidtools",
         "windowsdesktop",
         "Winget",
-        "Wireshark"
+        "Wireshark",
+        "xcopy"
     ]
 }

--- a/Evergreen/Apps/Get-McNeelRhino.ps1
+++ b/Evergreen/Apps/Get-McNeelRhino.ps1
@@ -19,9 +19,9 @@ Function Get-McNeelRhino {
     foreach ($Release in $res.Get.Update.GetEnumerator()) {
 
         # Query the Rhino update API
-
         # This requires redirection so Invoke-RestMethodWrapper produces "Operation is not valid due to the current state of the object."
-        $UpdateFeed = Invoke-RestMethod -Uri $Release.Value
+        $Uri = Resolve-InvokeWebRequest -Uri $Release.Value
+        $UpdateFeed = Invoke-RestMethod -Uri $Uri
 
         If ($Null -ne $UpdateFeed) {
 
@@ -32,7 +32,6 @@ Function Get-McNeelRhino {
                 URI     = $updateFeed.ProductVersionDescription.DownloadUrl
             }
             Write-Output -InputObject $PSObject
-
         }
     }
 }

--- a/Evergreen/Apps/Get-MicrosoftEdgeDriver.ps1
+++ b/Evergreen/Apps/Get-MicrosoftEdgeDriver.ps1
@@ -16,49 +16,44 @@ Function Get-MicrosoftEdgeDriver {
         $res = (Get-FunctionResource -AppName ("$($MyInvocation.MyCommand)".Split("-"))[1])
     )
 
-    # Query for each view
-    foreach ($view in $res.Get.Update.Views.GetEnumerator()) {
+    # Read the JSON and convert to a PowerShell object. Return the current release version of Edge
+    $updateFeed = Invoke-RestMethodWrapper -Uri $res.Get.Update.Uri
 
-        # Read the JSON and convert to a PowerShell object. Return the current release version of Edge
-        $updateFeed = Invoke-RestMethodWrapper -Uri "$($res.Get.Update.Uri)$($res.Get.Update.Views[$view.Key])"
+    # Read the JSON and build an array of platform, channel, architecture, version
+    if ($Null -ne $updateFeed) {
+        foreach ($platform in $res.Get.Update.Platforms) {
 
-        # Read the JSON and build an array of platform, channel, architecture, version
-        if ($Null -ne $updateFeed) {
-            foreach ($platform in $res.Get.Update.Platforms) {
+            # For each product (Stable, Beta etc.)
+            foreach ($channel in $res.Get.Update.Channels) {
+                foreach ($architecture in $res.Get.Update.Architectures) {
 
-                # For each product (Stable, Beta etc.)
-                foreach ($channel in $res.Get.Update.Channels) {
-                    foreach ($architecture in $res.Get.Update.Architectures) {
+                    # Sort for the latest release
+                    $latestRelease = $updateFeed | Where-Object { $_.Product -eq $channel } | `
+                        Select-Object -ExpandProperty "Releases" | `
+                        Where-Object { $_.Platform -eq $platform -and $_.Architecture -eq $architecture } | `
+                        Sort-Object -Property @{ Expression = { [System.Version]$_.ProductVersion }; Descending = $true } | `
+                        Select-Object -First 1
+                    Write-Verbose -Message "Found $($latestRelease.Count) releases."
 
-                        # Sort for the latest release
-                        $latestRelease = $updateFeed | Where-Object { $_.Product -eq $channel } | `
-                            Select-Object -ExpandProperty "Releases" | `
-                            Where-Object { $_.Platform -eq $platform -and $_.Architecture -eq $architecture } | `
-                            Sort-Object -Property @{ Expression = { [System.Version]$_.ProductVersion }; Descending = $true } | `
-                            Select-Object -First 1
+                    # Create the output object/s
+                    foreach ($release in $latestRelease) {
+                        if ($release.Artifacts.Count -gt 0) {
 
-                        # Create the output object/s
-                        ForEach ($release in $latestRelease) {
-                            If ($release.Artifacts.Count -gt 0) {
-                                $PSObject = [PSCustomObject] @{
-                                    Version      = $release.ProductVersion
-                                    Platform     = $release.Platform
-                                    Channel      = $channel
-                                    Architecture = $release.Architecture
-                                    Hash         = $(If ($release.Artifacts.Hash.Count -gt 1) { $release.Artifacts.Hash[0] } Else { $release.Artifacts.Hash })
-                                    URI          = $(If ($release.Artifacts.Location.Count -gt 1) { $release.Artifacts.Location[0] } Else { $release.Artifacts.Location })
-                                }
-
-                                # Output object to the pipeline
-                                Write-Output -InputObject $PSObject
+                            # Output object to the pipeline
+                            $PSObject = [PSCustomObject] @{
+                                Version      = $release.ProductVersion
+                                Channel      = $channel
+                                Architecture = $architecture
+                                URI          = $($res.Get.Download.Uri[$architecture] -replace "#version", $release.ProductVersion)
                             }
+                            Write-Output -InputObject $PSObject
                         }
                     }
                 }
             }
         }
-        else {
-            Write-Error -Message "$($MyInvocation.MyCommand): Failed to return content from: $($res.Get.Update.Uri)$($res.Get.Update.Views[$view.Key])."
-        }
+    }
+    else {
+        Write-Error -Message "$($MyInvocation.MyCommand): Failed to return content from: $($res.Get.Update.Uri)."
     }
 }

--- a/Evergreen/Apps/Get-MicrosoftEdgeWebView2Runtime.ps1
+++ b/Evergreen/Apps/Get-MicrosoftEdgeWebView2Runtime.ps1
@@ -16,49 +16,44 @@ Function Get-MicrosoftEdgeWebView2Runtime {
         $res = (Get-FunctionResource -AppName ("$($MyInvocation.MyCommand)".Split("-"))[1])
     )
 
-    # Query for each view
-    foreach ($view in $res.Get.Update.Views.GetEnumerator()) {
 
-        # Read the JSON and convert to a PowerShell object. Return the current release version of Edge
-        $updateFeed = Invoke-RestMethodWrapper -Uri "$($res.Get.Update.Uri)$($res.Get.Update.Views[$view.Key])"
+    # Read the JSON and convert to a PowerShell object. Return the current release version of Edge
+    $updateFeed = Invoke-RestMethodWrapper -Uri $res.Get.Update.Uri
 
-        # Read the JSON and build an array of platform, channel, architecture, version
-        if ($Null -ne $updateFeed) {
-            foreach ($platform in $res.Get.Update.Platforms) {
+    # Read the JSON and build an array of platform, channel, architecture, version
+    if ($Null -ne $updateFeed) {
+        foreach ($platform in $res.Get.Update.Platforms) {
 
-                # For each product (Stable, Beta etc.)
-                foreach ($channel in $res.Get.Update.Channels) {
-                    foreach ($architecture in $res.Get.Update.Architectures) {
+            # For each product (Stable, Beta etc.)
+            foreach ($channel in $res.Get.Update.Channels) {
+                foreach ($architecture in $res.Get.Update.Architectures) {
 
-                        # Sort for the latest release
-                        $latestRelease = $updateFeed | Where-Object { $_.Product -eq $channel } | `
-                            Select-Object -ExpandProperty "Releases" | `
-                            Where-Object { $_.Platform -eq $platform -and $_.Architecture -eq $architecture } | `
-                            Sort-Object -Property @{ Expression = { [System.Version]$_.ProductVersion }; Descending = $true } | `
-                            Select-Object -First 1
+                    # Sort for the latest release
+                    $latestRelease = $updateFeed | Where-Object { $_.Product -eq $channel } | `
+                        Select-Object -ExpandProperty "Releases" | `
+                        Where-Object { $_.Platform -eq $platform -and $_.Architecture -eq $architecture } | `
+                        Sort-Object -Property @{ Expression = { [System.Version]$_.ProductVersion }; Descending = $true } | `
+                        Select-Object -First 1
 
-                        # Create the output object/s
-                        ForEach ($release in $latestRelease) {
-                            If ($release.Artifacts.Count -gt 0) {
-                                $PSObject = [PSCustomObject] @{
-                                    Version      = $release.ProductVersion
-                                    Platform     = $release.Platform
-                                    Channel      = $channel
-                                    Architecture = $release.Architecture
-                                    Hash         = $(If ($release.Artifacts.Hash.Count -gt 1) { $release.Artifacts.Hash[0] } Else { $release.Artifacts.Hash })
-                                    URI          = $(If ($release.Artifacts.Location.Count -gt 1) { $release.Artifacts.Location[0] } Else { $release.Artifacts.Location })
-                                }
+                    # Create the output object/s
+                    ForEach ($release in $latestRelease) {
+                        If ($release.Artifacts.Count -gt 0) {
 
-                                # Output object to the pipeline
-                                Write-Output -InputObject $PSObject
+                            # Output object to the pipeline
+                            $PSObject = [PSCustomObject] @{
+                                Version      = $release.ProductVersion
+                                Channel      = $channel
+                                Architecture = $architecture
+                                URI          = $(Resolve-SystemNetWebRequest -Uri $res.Get.Download.Uri[$architecture]).ResponseUri.AbsoluteUri
                             }
+                            Write-Output -InputObject $PSObject
                         }
                     }
                 }
             }
         }
-        else {
-            Write-Error -Message "$($MyInvocation.MyCommand): Failed to return content from: $($res.Get.Update.Uri)$($res.Get.Update.Views[$view.Key])."
-        }
+    }
+    else {
+        Write-Error -Message "$($MyInvocation.MyCommand): Failed to return content from: $($res.Get.Update.Uri)."
     }
 }

--- a/Evergreen/Apps/Get-RStudio.ps1
+++ b/Evergreen/Apps/Get-RStudio.ps1
@@ -27,25 +27,28 @@ Function Get-RStudio {
     # Read the JSON and build an array of platform, channel, version
     If ($Null -ne $Content) {
 
-        # Match version number
-        try {
-            $Lines = $Content -split "\n"
-            $Version = [RegEx]::Match($Lines[0], $res.Get.Update.MatchVersion).Captures.Groups[1].Value
-        }
-        catch {
-            $Version = "Unknown"
-        }
-
         # Step through each installer type
-        ForEach ($item in $res.Get.Download.Uri.GetEnumerator()) {
+        foreach ($product in $res.Get.Update.Products) {
+            foreach ($platform in $res.Get.Update.Platforms) {
+                foreach ($item in $Content.$product.platforms.$platform) {
 
-            # Build the output object; Output object to the pipeline
-            $PSObject = [PSCustomObject] @{
-                Version = $Version
-                Type    = $item.Name
-                URI     = $res.Get.Download.Uri[$item.Key] -replace $res.Get.Download.ReplaceText, $Version
+                    # Build the output object; Output object to the pipeline
+                    $PSObject = [PSCustomObject] @{
+                        Version       = $item.version
+                        Sha256        = $item.sha256
+                        Size          = $item.size
+                        Channel       = $item.channel
+                        ProductName   = $Content.$product.name
+                        InstallerName = $item.name
+                        Type          = Get-FileType -File $item.link
+                        URI           = $item.link
+                    }
+                    Write-Output -InputObject $PSObject
+                }
             }
-            Write-Output -InputObject $PSObject
         }
+    }
+    else {
+        Write-Error -Message "$($MyInvocation.MyCommand): Unable to return usable content from: $($res.Get.Update.Uri)."
     }
 }

--- a/Evergreen/Manifests/McNeelRhino.json
+++ b/Evergreen/Manifests/McNeelRhino.json
@@ -3,8 +3,8 @@
 	"Source": "https://www.rhino3d.com/",
 	"Get": {
 		"Update": {
-		"7": "https://store.mcneel.com/api/v1/mcneelupdate/78464c2c-9aeb-456e-8c27-865a524f5ca0/release/win64/en-us/stable/7.0.20314.3001",
-		"6": "https://store.mcneel.com/api/v1/mcneelupdate/06bb1079-5a56-47a1-ad6d-0b45183d894b/release/win64/en-us/stable/6.16.19190.7001"
+		"7": "https://store.mcneel.com/api/v1/mcneelupdate/78464c2c-9aeb-456e-8c27-865a524f5ca0/release/win64/en-us/stable/",
+		"6": "https://store.mcneel.com/api/v1/mcneelupdate/06bb1079-5a56-47a1-ad6d-0b45183d894b/release/win64/en-us/stable/"
 		}
 	},
 	"Install": {

--- a/Evergreen/Manifests/MicrosoftEdgeDriver.json
+++ b/Evergreen/Manifests/MicrosoftEdgeDriver.json
@@ -4,14 +4,10 @@
     "Get": {
         "Update": {
             "Uri": "https://edgeupdates.microsoft.com/api/products",
-            "Views": {
-                "Consumer": ""
-            },
             "Platforms": [
                 "Windows"
             ],
             "Channels": [
-                "Canary",
                 "Dev",
                 "Beta",
                 "Stable"

--- a/Evergreen/Manifests/MicrosoftEdgeWebView2Runtime.json
+++ b/Evergreen/Manifests/MicrosoftEdgeWebView2Runtime.json
@@ -4,9 +4,6 @@
     "Get": {
         "Update": {
             "Uri": "https://edgeupdates.microsoft.com/api/products",
-            "Views": {
-                "Consumer": ""
-            },
             "Platforms": [
                 "Windows"
             ],

--- a/Evergreen/Manifests/RStudio.json
+++ b/Evergreen/Manifests/RStudio.json
@@ -1,9 +1,14 @@
 {
-	"Name": "RStudio",
+	"Name": "RStudio Desktop",
 	"Source": "https://www.rstudio.com/",
 	"Get": {
 		"Update": {
-            "Uri": "https://dailies.rstudio.com/rstudio/prairie-trillium/index.json",
+            "Uri": {
+				"Spotted Wakerobin": "https://dailies.rstudio.com/rstudio/prairie-trillium/index.json",
+				"Prairie Trillium": "https://dailies.rstudio.com/rstudio/prairie-trillium/index.json",
+				"Ghost Orchid": "https://dailies.rstudio.com/rstudio/prairie-trillium/index.json",
+				"Juliet Rose": "https://dailies.rstudio.com/rstudio/juliet-rose/index.json"
+			},
 			"Products": [
 				"desktop",
 				"desktop-pro"

--- a/Evergreen/Manifests/RStudio.json
+++ b/Evergreen/Manifests/RStudio.json
@@ -3,14 +3,15 @@
 	"Source": "https://www.rstudio.com/",
 	"Get": {
 		"Update": {
-            "Uri": "https://www.rstudio.org/links/check_for_update?version=1.2.1335&os=windows&format=kvp&manual=true",
-            "MatchVersion": "(\\d+(\\.\\d+){1,4}).*"
-		},
-		"Download": {
-            "Uri": {
-                "Exe": "https://download1.rstudio.org/desktop/windows/RStudio-#version.exe"
-            },
-            "ReplaceText": "#version"
+            "Uri": "https://dailies.rstudio.com/rstudio/prairie-trillium/index.json",
+			"Products": [
+				"desktop",
+				"desktop-pro"
+			],
+			"Platforms": [
+				"windows",
+				"windows-xcopy"
+			]
 		}
 	},
 	"Install": {

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,7 @@
 
 ## VERSION
 
+* Updates `RStudio` with new update source and adds Free and Pro editions [#318](https://github.com/aaronparker/evergreen/discussions/318)
 * Fixes an issue with installers returned by `MicrosoftEdgeDriver` and `MicrosoftEdgeWebView2Runtime`
 
 ## 2205.541

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,8 +2,13 @@
 
 ## VERSION
 
-* Updates `RStudio` with new update source and adds Free and Pro editions [#318](https://github.com/aaronparker/evergreen/discussions/318)
+* Updates `RStudio` with new update sources for all curren branches and now returns Free and Pro editions [#318](https://github.com/aaronparker/evergreen/discussions/318)
 * Fixes an issue with installers returned by `MicrosoftEdgeDriver` and `MicrosoftEdgeWebView2Runtime`
+* Updates `McNeelRhino` to work under PowerShell 6/7 - resolves an issue when using `Invoke-RestMethod` which does not follow a HTTP 302 response
+
+BREAKING CHANGES
+
+* `RStudio` returns new properties that will require filtering the output. Properties include: `Branch`, `Channel`, `ProductName`, and `InstallerName`
 
 ## 2205.541
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,9 @@
 # Change log
 
+## VERSION
+
+* Fixes an issue with installers returned by `MicrosoftEdgeDriver` and `MicrosoftEdgeWebView2Runtime`
+
 ## 2205.541
 
 * Fixes `MicrosoftSsms` to address returning the latest version and binaries [#305](https://github.com/aaronparker/evergreen/discussions/305)


### PR DESCRIPTION
* Updates `RStudio` with new update sources for all curren branches and now returns Free and Pro editions [#318](https://github.com/aaronparker/evergreen/discussions/318)
* Fixes an issue with installers returned by `MicrosoftEdgeDriver` and `MicrosoftEdgeWebView2Runtime`
* Updates `McNeelRhino` to work under PowerShell 6/7 - resolves an issue when using `Invoke-RestMethod` which does not follow a HTTP 302 response

BREAKING CHANGES

* `RStudio` returns new properties that will require filtering the output. Properties include: `Branch`, `Channel`, `ProductName`, and `InstallerName`