### PR TITLE
Development

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,6 +7,7 @@
         "adotcoop",
         "Akeo",
         "Anki",
+        "architecturekey",
         "Artifex",
         "aspnetcore",
         "Atlassian",

--- a/Evergreen/Apps/Get-MicrosoftWvdRemoteDesktop.ps1
+++ b/Evergreen/Apps/Get-MicrosoftWvdRemoteDesktop.ps1
@@ -32,6 +32,7 @@ Function Get-MicrosoftWvdRemoteDesktop {
                     Uri          = $Update.url
                     Method       = "Head"
                     ReturnObject = "Headers"
+                    ErrorAction  = "SilentlyContinue"
                 }
                 $Headers = Invoke-WebRequestWrapper @params
                 if ($Null -ne $Headers) {
@@ -39,7 +40,7 @@ Function Get-MicrosoftWvdRemoteDesktop {
                     $FileName = $($Headers['Content-Disposition'] -split $res.Get.Download.SplitText)[-1]
                 }
                 else {
-                    Write-Warning -Message "$($MyInvocation.MyCommand): Unable to resolve target file details."
+                    Write-Warning -Message "$($MyInvocation.MyCommand): Unable to retrieve headers from $($Update.url)."
                     $Date = "Unknown"
                     $FileName = "RemoteDesktop_$($Update.version)_$architecture.msi"
                 }

--- a/Evergreen/Apps/Get-VMwareTools.ps1
+++ b/Evergreen/Apps/Get-VMwareTools.ps1
@@ -60,7 +60,7 @@
                 URI          = $res.Get.Download.Uri -replace "#architecture", $architecture.Key `
                     -replace "#version", $LatestVersion.Version `
                     -replace "#build", $LatestVersion.ClientBuild `
-                    -replace "#architecture", $res.Get.Download.Architecture[$architecture.Key]
+                    -replace "#processor", $res.Get.Download.Architecture[$architecture.Key]
             }
             Write-Output -InputObject $PSObject
         }

--- a/Evergreen/Manifests/MicrosoftWvdMultimediaRedirection.json
+++ b/Evergreen/Manifests/MicrosoftWvdMultimediaRedirection.json
@@ -3,7 +3,7 @@
     "Source": "https://docs.microsoft.com/en-us/azure/virtual-desktop/multimedia-redirection",
     "Get": {
         "Download": {
-            "Uri": "https://query.prod.cms.rt.microsoft.com/cms/api/am/binary/RWIzIk",
+            "Uri": "https://query.prod.cms.rt.microsoft.com/cms/api/am/binary/RE4QWrF",
             "MatchFilename": "(MsMMRHostInstaller.*msi)",
             "MatchVersion": "(\\d+(\\.\\d+){1,4})"
         }

--- a/Evergreen/Manifests/MicrosoftWvdRemoteDesktop.json
+++ b/Evergreen/Manifests/MicrosoftWvdRemoteDesktop.json
@@ -2,25 +2,33 @@
     "Name": "Microsoft Remote Desktop",
     "Source": "https://docs.microsoft.com/en-us/azure/virtual-desktop/connect-windows-7-10",
     "Get": {
-        "Download": {
+        "Update": {
             "Uri": {
-                "Public": {
-                    "x64": "https://go.microsoft.com/fwlink/?linkid=2068602",
-                    "x86": "https://go.microsoft.com/fwlink/?linkid=2098960",
-                    "ARM64": "https://go.microsoft.com/fwlink/?linkid=2098961"
+                "Dogfood": {
+                    "ARM64": "https://go.microsoft.com/fwlink/?linkid=2099344",
+                    "x64": "https://go.microsoft.com/fwlink/?linkid=2099343",
+                    "x86": "https://go.microsoft.com/fwlink/?linkid=2099064"
                 },
                 "Insider": {
-                    "x64": "https://go.microsoft.com/fwlink/?linkid=2139233",
-                    "x86": "https://go.microsoft.com/fwlink/?linkid=2139144",
-                    "ARM64": "https://go.microsoft.com/fwlink/?linkid=2139368"
+                    "ARM64": "https://go.microsoft.com/fwlink/?linkid=2098962",
+                    "x64": "https://go.microsoft.com/fwlink/?linkid=2099433",
+                    "x86": "https://go.microsoft.com/fwlink/?linkid=2099432"
+                },
+                "Public": {
+                    "ARM64": "https://go.microsoft.com/fwlink/?linkid=2099066",
+                    "x64": "https://go.microsoft.com/fwlink/?linkid=2098963",
+                    "x86": "https://go.microsoft.com/fwlink/?linkid=2099065"
                 }
-            },
+            }
+        },
+        "Download": {
             "ApiUri": "https://query.prod.cms.rt.microsoft.com/cms/api",
             "ApiHeader1": "X-CMS-Tenant",
             "ApiHeader2": "X-CMS-Type",
             "ApiHeader3": "X-CMS-DocumentId",
             "MatchFilename": "(RemoteDesktop.*msi)",
             "MatchVersion": "(\\d+(\\.\\d+){1,4})",
+            "SplitText": "filename=",
             "DatePattern": "ddd, dd MMM yyyy HH:mm:ss GMT"
         }
     },

--- a/Evergreen/Manifests/MicrosoftWvdRemoteDesktop.json
+++ b/Evergreen/Manifests/MicrosoftWvdRemoteDesktop.json
@@ -5,9 +5,9 @@
         "Download": {
             "Uri": {
                 "Public": {
-                    "x64": "https://go.microsoft.com/fwlink/?linkid=2139369",
-                    "x86": "https://go.microsoft.com/fwlink/?linkid=2139144",
-                    "ARM64": "https://go.microsoft.com/fwlink/?linkid=2139368"
+                    "x64": "https://go.microsoft.com/fwlink/?linkid=2068602",
+                    "x86": "https://go.microsoft.com/fwlink/?linkid=2098960",
+                    "ARM64": "https://go.microsoft.com/fwlink/?linkid=2098961"
                 },
                 "Insider": {
                     "x64": "https://go.microsoft.com/fwlink/?linkid=2139233",

--- a/Evergreen/Manifests/VMwareTools.json
+++ b/Evergreen/Manifests/VMwareTools.json
@@ -14,7 +14,7 @@
 			]
 		},
 		"Download": {
-			"Uri": "https://packages.vmware.com/tools/releases/latest/windows/#architecture/VMware-tools-#version-#build-#architecture.exe",
+			"Uri": "https://packages.vmware.com/tools/releases/#version/windows/#architecture/VMware-tools-#version-#build-#processor.exe",
 			"Architecture": {
 				"x64": "x86_64",
 				"x86": "i386"

--- a/Evergreen/Private/Invoke-WebRequestWrapper.ps1
+++ b/Evergreen/Private/Invoke-WebRequestWrapper.ps1
@@ -87,7 +87,6 @@ public class TrustAllCertsPolicy : ICertificatePolicy {
         Method          = $Method
         UserAgent       = $UserAgent
         UseBasicParsing = $True
-        ErrorAction     = "Continue"
     }
 
     # Set additional parameters

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,9 @@
 # Change log
 
+## VERSION
+
+* Updates the approach to detecting new versions in `MicrosoftWvdRemoteDesktop`. Uses update details available in JSON format and addresses issue [#352](https://github.com/aaronparker/evergreen/discussions/352)
+
 ## 2206.583
 
 * Fixes an issue with `MozillaThunderbird` when attempting to return downloads for the full language list [#350](https://github.com/aaronparker/evergreen/discussions/350)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -3,6 +3,8 @@
 ## VERSION
 
 * Updates the approach to detecting new versions in `MicrosoftWvdRemoteDesktop`. Uses update details available in JSON format and addresses issue [#352](https://github.com/aaronparker/evergreen/discussions/352)
+* Fixes and issue in `VMwareTools` where the download URL returned doesn't match the latest version available [#336](https://github.com/aaronparker/evergreen/discussions/336)
+* Removes hard-coded `ErrorAction = Continue` in private function `Invoke-WebRequestWrapper` to enable setting `ErrorAction` preference when calling this function from an application function
 
 ## 2206.583
 

--- a/docs/issues.md
+++ b/docs/issues.md
@@ -101,6 +101,21 @@ The product release feed used by the Microsoft SQL Server Management Studio (e.g
 
 The version number returned by the Microsoft Teams update API may be slightly different to the version number displayed in the `ProductVersion` property in the MSI or in Programs and Features. For example, `Get-EvergreenApp -Name MicrosoftTeams` may report a version number of `1.4.00.8872`, but the Windows Installer may report `1.4.0.8872`. Also see [Get-MicrosoftTeams displays slightly wrong formatted version number](https://github.com/aaronparker/Evergreen/issues/58).
 
+### MicrosoftWvdRemoteDesktop
+
+`MicrosoftWvdRemoteDesktop` may report an HTTP 503 error from some URLs (see an example below). This is intermittent behavior, but the function should still usable data. Suppress this warning with `-WarningAction "SilentlyContinue".
+
+```powershell
+WARNING: Invoke-WebRequestWrapper: Error at URI: https://query.prod.cms.rt.microsoft.com/cms/api/am/binary/RE50Mp8.
+WARNING: Invoke-WebRequestWrapper: Error encountered: Response status code does not indicate success: 503 (Service Unavailable)..
+WARNING: Invoke-WebRequestWrapper: For troubleshooting steps see: https://stealthpuppy.com/evergreen/troubleshoot/.
+WARNING: Get-MicrosoftWvdRemoteDesktop: Unable to retrieve headers from https://query.prod.cms.rt.microsoft.com/cms/api/am/binary/RE50Mp8.
+WARNING: Invoke-WebRequestWrapper: Error at URI: https://query.prod.cms.rt.microsoft.com/cms/api/am/binary/RE50t3P.
+WARNING: Invoke-WebRequestWrapper: Error encountered: Response status code does not indicate success: 503 (Service Unavailable)..
+WARNING: Invoke-WebRequestWrapper: For troubleshooting steps see: https://stealthpuppy.com/evergreen/troubleshoot/.
+WARNING: Get-MicrosoftWvdRemoteDesktop: Unable to retrieve headers from https://query.prod.cms.rt.microsoft.com/cms/api/am/binary/RE50t3P.
+```
+
 ### MozillaFirefox
 
 #### Language Support

--- a/tests/PublicFunctions.Tests.ps1
+++ b/tests/PublicFunctions.Tests.ps1
@@ -11,7 +11,7 @@ BeforeDiscovery {
     # Get the supported applications
     # Sort randomly so that we get test various GitHub applications when we have API request limits
     $Applications = Find-EvergreenApp | `
-        Where-Object { $_.Name -notmatch "FileZilla|Tableau|MicrosoftWvdRtcService|PaintDotNet" } | `
+        Where-Object { $_.Name -notmatch "FileZilla|Tableau|MicrosoftWvdRtcService|MicrosoftWvdBootloader|MicrosoftWvdMultimediaRedirection|PaintDotNet" } | `
         Sort-Object { Get-Random } | Select-Object -ExpandProperty "Name"
 
     # Get details for Microsoft Edge

--- a/tests/PublicFunctions.Tests.ps1
+++ b/tests/PublicFunctions.Tests.ps1
@@ -11,7 +11,7 @@ BeforeDiscovery {
     # Get the supported applications
     # Sort randomly so that we get test various GitHub applications when we have API request limits
     $Applications = Find-EvergreenApp | `
-        Where-Object { $_.Name -notmatch "FileZilla|Tableau|MicrosoftWvdRtcService" } | `
+        Where-Object { $_.Name -notmatch "FileZilla|Tableau|MicrosoftWvdRtcService|PaintDotNet" } | `
         Sort-Object { Get-Random } | Select-Object -ExpandProperty "Name"
 
     # Get details for Microsoft Edge

--- a/tests/PublicFunctions.Tests.ps1
+++ b/tests/PublicFunctions.Tests.ps1
@@ -10,8 +10,9 @@ param ()
 BeforeDiscovery {
     # Get the supported applications
     # Sort randomly so that we get test various GitHub applications when we have API request limits
+    $AppsToSkip = "FileZilla|Tableau|MicrosoftWvdRemoteDesktop|MicrosoftWvdRtcService|MicrosoftWvdBootloader|MicrosoftWvdMultimediaRedirection|PaintDotNet"
     $Applications = Find-EvergreenApp | `
-        Where-Object { $_.Name -notmatch "FileZilla|Tableau|MicrosoftWvdRtcService|MicrosoftWvdBootloader|MicrosoftWvdMultimediaRedirection|PaintDotNet" } | `
+        Where-Object { $_.Name -notmatch $AppsToSkip } | `
         Sort-Object { Get-Random } | Select-Object -ExpandProperty "Name"
 
     # Get details for Microsoft Edge


### PR DESCRIPTION
* Updates the approach to detecting new versions in `MicrosoftWvdRemoteDesktop`. Uses update details available in JSON format and addresses issue [#352](https://github.com/aaronparker/evergreen/discussions/352)
* Fixes and issue in `VMwareTools` where the download URL returned doesn't match the latest version available [#336](https://github.com/aaronparker/evergreen/discussions/336)
* Removes hard-coded `ErrorAction = Continue` in private function `Invoke-WebRequestWrapper` to enable setting `ErrorAction` preference when calling this function from an application function