### PR TITLE
Update Bitwarden repository url

### DIFF
--- a/Evergreen/Manifests/BitwardenDesktop.json
+++ b/Evergreen/Manifests/BitwardenDesktop.json
@@ -2,9 +2,14 @@
 	"Name": "Bitwarden Desktop",
 	"Source": "https://bitwarden.com/",
 	"Get": {
-		"Uri": "https://api.github.com/repos/bitwarden/clients/releases",
-		"MatchVersion": "(\\d+(\\.\\d+){1,4}).*",
-		"MatchFileTypes": "\\.exe$|\\.msi$"
+		"Update": {
+			"Uri": "https://artifacts.bitwarden.com/desktop/latest.yml",
+			"MatchVersion": "version:\\s(\\d+(\\.\\d+){1,4})"
+		},
+		"Download": {
+			"Uri": "https://artifacts.bitwarden.com/desktop/Bitwarden-Installer-#version.exe",
+			"ReplaceText": "#version"
+		}
 	},
 	"Install": {
 		"Setup": "Bitwarden*.exe",

--- a/Evergreen/Manifests/BitwardenDesktop.json
+++ b/Evergreen/Manifests/BitwardenDesktop.json
@@ -2,7 +2,7 @@
 	"Name": "Bitwarden Desktop",
 	"Source": "https://bitwarden.com/",
 	"Get": {
-		"Uri": "https://api.github.com/repos/bitwarden/desktop/releases/latest",
+		"Uri": "https://api.github.com/repos/bitwarden/clients/releases",
 		"MatchVersion": "(\\d+(\\.\\d+){1,4}).*",
 		"MatchFileTypes": "\\.exe$|\\.msi$"
 	},


### PR DESCRIPTION
This fixes #365

However note unfortunately the new combined Bitwarden client repository doesn't always tag the latest releases for reach client as "latest" so the full releases feed is used. This has the unfortunate side-effect of returning not just the current release but all releases and assets that match the filters in the manifest.

One of the "correct" solutions to this would be refactoring `Get-GitHubRepoRelease` to accept a filter for `VersionTag` and filter on the "desktop-" prefix and stop returning output when the version changes. 

I haven't done this as:
- From a quick search OpenJDK is also "broken" in this way returning multiple versions
- There are many ways to refactor `Get-GitHubRepoRelease` and didn't want to start making decisions about this unilaterally without discussion