### PR TITLE
Add missing link for Adobe Acrobat Reader x64 MUI

### DIFF
--- a/Evergreen/Manifests/AdobeAcrobat.json
+++ b/Evergreen/Manifests/AdobeAcrobat.json
@@ -35,7 +35,8 @@
                         "Multi": "https://ardownload2.adobe.com/pub/adobe/reader/win/Acrobat#track/#version/AcroRdr#trackUpd#version_MUI.msp"
                     },
                     "x64": {
-                        "Neutral": "https://ardownload2.adobe.com/pub/adobe/acrobat/win/Acrobat#track/#version/AcroRdr#trackx64Upd#version.msp"
+                        "Neutral": "https://ardownload2.adobe.com/pub/adobe/acrobat/win/Acrobat#track/#version/AcroRdr#trackx64Upd#version.msp",
+                        "Multi": "https://ardownload2.adobe.com/pub/adobe/acrobat/win/Acrobat#track/#version/AcroRdr#trackx64Upd#version_MUI.msp"
                     }
                 }
             },


### PR DESCRIPTION
Fix for issue #384. Now you can close for real it and decomissiom the the other command that no longuer work I suppose. Up to you. Thanks.