### PR TITLE
OpenLens: adding to repo

### DIFF
--- a/Evergreen/Apps/Get-OpenLens.ps1
+++ b/Evergreen/Apps/Get-OpenLens.ps1
@@ -1,0 +1,27 @@
+Function Get-OpenLens {
+    <#
+        .SYNOPSIS
+            Returns the available OpenLens versions.
+
+        .NOTES
+            Author: Kirill Trofimov
+    #>
+    [OutputType([System.Management.Automation.PSObject])]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseSingularNouns", "")]
+    [CmdletBinding(SupportsShouldProcess = $False)]
+    param (
+        [Parameter(Mandatory = $False, Position = 0)]
+        [ValidateNotNull()]
+        [System.Management.Automation.PSObject]
+        $res = (Get-FunctionResource -AppName ("$($MyInvocation.MyCommand)".Split("-"))[1])
+    )
+
+    # Pass the repo releases API URL and return a formatted object
+    $params = @{
+        Uri          = $res.Get.Uri
+        MatchVersion = $res.Get.MatchVersion
+        Filter       = $res.Get.MatchFileTypes
+    }
+    $object = Get-GitHubRepoRelease @params
+    Write-Output -InputObject $object
+}

--- a/Evergreen/Manifests/OpenLens.json
+++ b/Evergreen/Manifests/OpenLens.json
@@ -1,0 +1,23 @@
+{
+	"Name": "OpenLens",
+	"Source": "https://github.com/MuhammedKalkan/OpenLens/",
+	"Get": {
+		"Uri": "https://api.github.com/repos/MuhammedKalkan/OpenLens/releases/latest",
+		"MatchVersion": "(\\d+(\\.\\d+){1,4}).*",
+		"MatchFileTypes": "\\.exe$"
+	},
+	"Install": {
+		"Setup": "OpenLens-*.exe",
+		"Preinstall": "",
+		"Physical": {
+			"Arguments": "",
+			"PostInstall": [
+			]
+		},
+		"Virtual": {
+			"Arguments": "",
+			"PostInstall": [
+			]
+		}
+	}
+}


### PR DESCRIPTION
Hello, for some reasons people want to use Lens without login/creating account in Mirantis, so I prepared installation script (based on Microsoft Powertoys) for OpenLens.

* https://github.com/MuhammedKalkan/OpenLens

```Powershell
PS C:\Users\g3rhard> Get-EvergreenApp -Name "OpenLens"
Version      : 6.1.2
Platform     : Windows
Architecture : x86
Type         : exe
Date         : 2022-10-04T18:49:07Z
Size         : 124296177
URI          : https://github.com/MuhammedKalkan/OpenLens/releases/download/v6.1.2/OpenLens-6.1.2.exe

PS C:\Users\g3rhard> Get-EvergreenApp -Name "OpenLens" | Save-EvergreenApp -CustomPath $HOME/Downloads

    Directory: C:\Users\g3rhard\Downloads

Mode                 LastWriteTime         Length Name
----                 -------------         ------ ----
-a----         10/7/2022   9:21 AM      124296177 OpenLens-6.1.2.exe
```