### PR TITLE
Git Extensions: Adding app

### DIFF
--- a/Evergreen/Apps/Get-GitExtensions.ps1
+++ b/Evergreen/Apps/Get-GitExtensions.ps1
@@ -1,0 +1,27 @@
+Function Get-GitExtensions {
+    <#
+        .SYNOPSIS
+            Returns the available Git Extensions versions.
+
+        .NOTES
+            Author: Kirill Trofimov
+    #>
+    [OutputType([System.Management.Automation.PSObject])]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseSingularNouns", "")]
+    [CmdletBinding(SupportsShouldProcess = $False)]
+    param (
+        [Parameter(Mandatory = $False, Position = 0)]
+        [ValidateNotNull()]
+        [System.Management.Automation.PSObject]
+        $res = (Get-FunctionResource -AppName ("$($MyInvocation.MyCommand)".Split("-"))[1])
+    )
+
+    # Pass the repo releases API URL and return a formatted object
+    $params = @{
+        Uri          = $res.Get.Uri
+        MatchVersion = $res.Get.MatchVersion
+        Filter       = $res.Get.MatchFileTypes
+    }
+    $object = Get-GitHubRepoRelease @params
+    Write-Output -InputObject $object
+}

--- a/Evergreen/Manifests/GitExtensions.json
+++ b/Evergreen/Manifests/GitExtensions.json
@@ -1,0 +1,20 @@
+{
+	"Name": "Git Extensions",
+	"Source": "https://github.com/gitextensions/gitextensions",
+	"Get": {
+		"Uri": "https://api.github.com/repos/gitextensions/gitextensions/releases/latest",
+		"MatchVersion": "(\\d+(\\.\\d+){1,4}).*",
+		"MatchFileTypes": "\\.msi$|\\.zip$"
+	},
+	"Install": {
+		"Setup": "GitExtensions*.msi",
+		"Physical": {
+			"Arguments": "",
+			"PostInstall": []
+		},
+		"Virtual": {
+			"Arguments": "",
+			"PostInstall": []
+		}
+	}
+}


### PR DESCRIPTION
Hello, another app for Evergreen:

* https://github.com/gitextensions/gitextensions/

```Powershell
PS C:\Users\g3rhard> Get-EvergreenApp -Name "GitExtensions"

Version      : 3.5.4
Platform     : Windows
Architecture : x86
Type         : msi
Date         : 2021-09-29T08:43:59Z
Size         : 23908352
URI          : https://github.com/gitextensions/gitextensions/releases/download/v3.5.4/GitExtensions-3.5.4.12724-65f0
               1f399.msi

Version      : 3.5.4
Platform     : Windows
Architecture : x86
Type         : zip
Date         : 2021-09-29T08:43:59Z
Size         : 23153128
URI          : https://github.com/gitextensions/gitextensions/releases/download/v3.5.4/GitExtensions-Portable-3.5.4.1
               2724-65f01f399.zip
```

Using latest stable version (it doesn't make sense to use "beta" releases).