### PR TITLE
KeeWeb: Adding app

### DIFF
--- a/Evergreen/Apps/Get-KeeWeb.ps1
+++ b/Evergreen/Apps/Get-KeeWeb.ps1
@@ -1,0 +1,27 @@
+Function Get-KeeWeb {
+    <#
+        .SYNOPSIS
+            Returns the available KeeWeb versions.
+
+        .NOTES
+            Author: Kirill Trofimov
+    #>
+    [OutputType([System.Management.Automation.PSObject])]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseSingularNouns", "")]
+    [CmdletBinding(SupportsShouldProcess = $False)]
+    param (
+        [Parameter(Mandatory = $False, Position = 0)]
+        [ValidateNotNull()]
+        [System.Management.Automation.PSObject]
+        $res = (Get-FunctionResource -AppName ("$($MyInvocation.MyCommand)".Split("-"))[1])
+    )
+
+    # Pass the repo releases API URL and return a formatted object
+    $params = @{
+        Uri          = $res.Get.Uri
+        MatchVersion = $res.Get.MatchVersion
+        Filter       = $res.Get.MatchFileTypes
+    }
+    $object = Get-GitHubRepoRelease @params
+    Write-Output -InputObject $object
+}

--- a/Evergreen/Manifests/KeeWeb.json
+++ b/Evergreen/Manifests/KeeWeb.json
@@ -1,0 +1,20 @@
+{
+	"Name": "KeeWeb",
+	"Source": "https://github.com/keeweb/keeweb",
+	"Get": {
+		"Uri": "https://api.github.com/repos/keeweb/keeweb/releases/latest",
+		"MatchVersion": "(\\d+(\\.\\d+){1,4}).*",
+		"MatchFileTypes": "\\.exe$|\\.zip$"
+	},
+	"Install": {
+		"Setup": "KeeWeb*.exe",
+		"Physical": {
+			"Arguments": "/NCRC /S",
+			"PostInstall": []
+		},
+		"Virtual": {
+			"Arguments": "",
+			"PostInstall": []
+		}
+	}
+}


### PR DESCRIPTION
Hello, another app for Evergreen:

* https://github.com/keeweb/keeweb/

```Powershell
PS C:\Users\g3rhard> Get-EvergreenApp -Name KeeWeb

Version      : 1.18.7
Platform     : Windows
Architecture : x86
Type         : zip
Date         : 2021-07-18T14:21:55Z
Size         : 7160996
URI          : https://github.com/keeweb/keeweb/releases/download/v1.18.7/KeeWeb-1.18.7.html.zip

Version      : 1.18.7
Platform     : Windows
Architecture : ARM64
Type         : exe
Date         : 2021-07-18T14:21:55Z
Size         : 59490304
URI          : https://github.com/keeweb/keeweb/releases/download/v1.18.7/KeeWeb-1.18.7.win.arm64.exe

Version      : 1.18.7
Platform     : Windows
Architecture : ARM64
Type         : zip
Date         : 2021-07-18T14:21:55Z
Size         : 85382735
URI          : https://github.com/keeweb/keeweb/releases/download/v1.18.7/KeeWeb-1.18.7.win.arm64.zip

Version      : 1.18.7
Platform     : Windows
Architecture : x86
Type         : exe
Date         : 2021-07-18T14:21:55Z
Size         : 60156888
URI          : https://github.com/keeweb/keeweb/releases/download/v1.18.7/KeeWeb-1.18.7.win.ia32.exe

Version      : 1.18.7
Platform     : Windows
Architecture : x86
Type         : zip
Date         : 2021-07-18T14:21:55Z
Size         : 79082537
URI          : https://github.com/keeweb/keeweb/releases/download/v1.18.7/KeeWeb-1.18.7.win.ia32.zip

Version      : 1.18.7
Platform     : Windows
Architecture : x64
Type         : exe
Date         : 2021-07-18T14:21:55Z
Size         : 63026752
URI          : https://github.com/keeweb/keeweb/releases/download/v1.18.7/KeeWeb-1.18.7.win.x64.exe

Version      : 1.18.7
Platform     : Windows
Architecture : x64
Type         : zip
Date         : 2021-07-18T14:21:55Z
Size         : 83753334
URI          : https://github.com/keeweb/keeweb/releases/download/v1.18.7/KeeWeb-1.18.7.win.x64.zip

```