### PR TITLE
Add proxy server support

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -21,6 +21,7 @@
         "codecov",
         "Codelerity",
         "Corretto",
+        "Creds",
         "currentversion",
         "Cyberduck",
         "dbeaver",

--- a/Evergreen/Apps/Get-FoxitPDFEditor.ps1
+++ b/Evergreen/Apps/Get-FoxitPDFEditor.ps1
@@ -19,7 +19,17 @@ Function Get-FoxitPDFEditor {
 
     # Query the Foxit PDF Editor package download form to get the JSON
     # TODO: Fix issue with Invoke-RestMethodWrapper that produces "Operation is not valid due to the current state of the object."
-    $updateFeed = Invoke-RestMethod -Uri $res.Get.Update.Uri -UseBasicParsing
+    $params = @{
+        Uri             = $res.Get.Update.Uri
+        UseBasicParsing = $true
+    }
+    if (Test-ProxyEnv) {
+        $params.Proxy = $script:EvergreenProxy
+    }
+    if (Test-ProxyEnv -Creds) {
+        $params.ProxyCredential = $script:EvergreenProxyCreds
+    }
+    $updateFeed = Invoke-RestMethod @params
 
     If ($Null -ne $updateFeed) {
 

--- a/Evergreen/Apps/Get-FoxitReader.ps1
+++ b/Evergreen/Apps/Get-FoxitReader.ps1
@@ -19,7 +19,17 @@ Function Get-FoxitReader {
 
     # Query the Foxit Reader package download form to get the JSON
     # TODO: Fix issue with Invoke-RestMethodWrapper that produces "Operation is not valid due to the current state of the object."
-    $updateFeed = Invoke-RestMethod -Uri $res.Get.Update.Uri -UseBasicParsing
+    $params = @{
+        Uri             = $res.Get.Update.Uri
+        UseBasicParsing = $true
+    }
+    if (Test-ProxyEnv) {
+        $params.Proxy = $script:EvergreenProxy
+    }
+    if (Test-ProxyEnv -Creds) {
+        $params.ProxyCredential = $script:EvergreenProxyCreds
+    }
+    $updateFeed = Invoke-RestMethod @params
 
     If ($Null -ne $updateFeed) {
 

--- a/Evergreen/Private/Get-GitHubRepoRelease.ps1
+++ b/Evergreen/Private/Get-GitHubRepoRelease.ps1
@@ -1,4 +1,4 @@
-Function Get-GitHubRepoRelease {
+function Get-GitHubRepoRelease {
     <#
         .SYNOPSIS
             Calls the GitHub Releases API passed via $Uri, validates the response and returns a formatted object
@@ -53,7 +53,7 @@ Function Get-GitHubRepoRelease {
         $params = @{
             Uri = "https://api.github.com/rate_limit"
         }
-        If ($Token) { $params.Headers = @{ Authorization = "token $TokenValue" } }
+        if ($Token) { $params.Headers = @{ Authorization = "token $TokenValue" } }
         Write-Verbose -Message "$($MyInvocation.MyCommand): Checking for how many requests to the GitHub API we have left."
         $GitHubRate = Invoke-RestMethodWrapper @params
     }
@@ -93,7 +93,13 @@ Function Get-GitHubRepoRelease {
                     UserAgent          = "github-aaronparker-evergreen"
                     Uri                = $Uri
                 }
-                If ($Token) { $params.Headers = @{ Authorization = "token $TokenValue" } }
+                if (Test-ProxyEnv) {
+                    $params.Proxy = $script:EvergreenProxy
+                }
+                if (Test-ProxyEnv -Creds) {
+                    $params.ProxyCredential = $script:EvergreenProxyCreds
+                }
+                if ($Token) { $params.Headers = @{ Authorization = "token $TokenValue" } }
                 Write-Verbose -Message "$($MyInvocation.MyCommand): Get GitHub release from: $Uri."
                 $response = $True
                 $release = Invoke-RestMethod @params
@@ -132,7 +138,7 @@ Function Get-GitHubRepoRelease {
                             Write-Verbose -Message "$($MyInvocation.MyCommand): Validation failed."
                             $validate = $False
                             $missingProperties | ForEach-Object {
-                                Throw [System.Management.Automation.ValidationMetadataException] "$($MyInvocation.MyCommand): Property: '$_' missing"
+                                throw [System.Management.Automation.ValidationMetadataException] "$($MyInvocation.MyCommand): Property: '$_' missing"
                             }
                         }
                     }

--- a/Evergreen/Private/Invoke-RestMethodWrapper.ps1
+++ b/Evergreen/Private/Invoke-RestMethodWrapper.ps1
@@ -106,10 +106,10 @@ public class TrustAllCertsPolicy : ICertificatePolicy {
         $irmParams.SslProtocol = $SslProtocol
     }
     if (Test-ProxyEnv) {
-        $iwrParams.Proxy = $script:EvergreenProxy
+        $irmParams.Proxy = $script:EvergreenProxy
     }
     if (Test-ProxyEnv -Creds) {
-        $iwrParams.ProxyCredential = $script:EvergreenProxyCreds
+        $irmParams.ProxyCredential = $script:EvergreenProxyCreds
     }
     foreach ($item in $irmParams.GetEnumerator()) {
         Write-Verbose -Message "$($MyInvocation.MyCommand): Invoke-RestMethod parameter: [$($item.name): $($item.value)]."

--- a/Evergreen/Private/Remove-ProxyEnv.ps1
+++ b/Evergreen/Private/Remove-ProxyEnv.ps1
@@ -1,0 +1,20 @@
+function Remove-ProxyEnv {
+    <#
+        .SYNOPSIS
+            Remove proxy server and credentials information from environment variables
+    #>
+    [CmdletBinding(SupportsShouldProcess = $True)]
+    param (
+    )
+
+    begin {}
+    process {
+        try {
+            Remove-Variable -Name "EvergreenProxy" -Scope "Script" -Force -ErrorAction "SilentlyContinue"
+            Remove-Variable -Name "EvergreenProxyCreds" -Scope "Script" -Force -ErrorAction "SilentlyContinue"
+        }
+        catch [System.Exception] {
+            Write-Warning -Message "$($MyInvocation.MyCommand): Failed to remove proxy variables."
+        }
+    }
+}

--- a/Evergreen/Private/Resolve-InvokeWebRequest.ps1
+++ b/Evergreen/Private/Resolve-InvokeWebRequest.ps1
@@ -28,9 +28,15 @@ Function Resolve-InvokeWebRequest {
         UserAgent          = $UserAgent
         ErrorAction        = "SilentlyContinue"
     }
+    if (Test-ProxyEnv) {
+        $iwrParams.Proxy = $script:EvergreenProxy
+    }
+    if (Test-ProxyEnv -Creds) {
+        $iwrParams.ProxyCredential = $script:EvergreenProxyCreds
+    }
     Write-Verbose -Message "$($MyInvocation.MyCommand): Resolving URI: [$Uri]."
-    ForEach ($item in $iwrParams.GetEnumerator()) {
-        Write-Verbose -Message "$($MyInvocation.MyCommand): Invoke-RestMethod parameter: [$($item.name): $($item.value)]."
+    foreach ($item in $iwrParams.GetEnumerator()) {
+        Write-Verbose -Message "$($MyInvocation.MyCommand): Invoke-WebRequest parameter: [$($item.name): $($item.value)]."
     }
 
     if (Test-PSCore) {

--- a/Evergreen/Private/Resolve-SystemNetWebRequest.ps1
+++ b/Evergreen/Private/Resolve-SystemNetWebRequest.ps1
@@ -17,11 +17,30 @@ Function Resolve-SystemNetWebRequest {
     )
 
     try {
-        Write-Verbose -Message "$($MyInvocation.MyCommand): Attempting to resolve: $Uri."
         $httpWebRequest = [System.Net.WebRequest]::Create($Uri)
         $httpWebRequest.MaximumAutomaticRedirections = $MaximumRedirection
         $httpWebRequest.AllowAutoRedirect = $true
-        $httpWebRequest.UseDefaultCredentials = $true
+
+        if (Test-ProxyEnv) {
+            $ProxyObj = New-Object -TypeName "System.Net.WebProxy"
+            $ProxyObj.Address = $script:EvergreenProxy
+            $ProxyObj.UseDefaultCredentials = $true
+            $httpWebRequest.Proxy = $ProxyObj
+
+            if (Test-ProxyEnv -Creds) {
+                $ProxyObj.UseDefaultCredentials = $false
+                $ProxyObj.Credentials = $script:EvergreenProxyCreds
+
+                $httpWebRequest.UseDefaultCredentials = $false
+                $httpWebRequest.Proxy = $ProxyObj
+                $httpWebRequest.Credentials = $script:EvergreenProxyCreds
+            }
+        }
+        else {
+            $httpWebRequest.UseDefaultCredentials = $true
+        }
+
+        Write-Verbose -Message "$($MyInvocation.MyCommand): Attempting to resolve: $Uri."
         $webResponse = $httpWebRequest.GetResponse()
     }
     catch {

--- a/Evergreen/Private/Set-ProxyEnv.ps1
+++ b/Evergreen/Private/Set-ProxyEnv.ps1
@@ -1,0 +1,46 @@
+function Set-ProxyEnv {
+    <#
+        .SYNOPSIS
+            Set proxy server and credentials information into environment variables that other functions can use
+    #>
+    [CmdletBinding(SupportsShouldProcess = $True)]
+    param (
+        [Parameter(Mandatory = $False, Position = 0)]
+        [System.String] $Proxy,
+
+        [Parameter(Mandatory = $False, Position = 1)]
+        [System.Management.Automation.PSCredential]
+        $ProxyCredential = [System.Management.Automation.PSCredential]::Empty
+    )
+
+    begin {}
+    process {
+        try {
+            if ($PSBoundParameters.ContainsKey("Proxy")) {
+                if ($PSCmdlet.ShouldProcess("Set proxy server variable", "Proxy")) {
+                    $params = @{
+                        Name  = "EvergreenProxy"
+                        Value = $Proxy
+                        Scope = "Script"
+                        Force = $True
+                    }
+                    New-Variable @params
+                }
+            }
+            if ($PSBoundParameters.ContainsKey("ProxyCredential")) {
+                if ($PSCmdlet.ShouldProcess("Set proxy credential variable", "ProxyCredential")) {
+                    $params = @{
+                        Name  = "EvergreenProxyCreds"
+                        Value = $ProxyCredential
+                        Scope = "Script"
+                        Force = $True
+                    }
+                    New-Variable @params
+                }
+            }
+        }
+        catch [System.Exception] {
+            throw $_
+        }
+    }
+}

--- a/Evergreen/Private/Test-ProxyEnv.ps1
+++ b/Evergreen/Private/Test-ProxyEnv.ps1
@@ -1,0 +1,21 @@
+function Test-ProxyEnv {
+    <#
+        .SYNOPSIS
+            Return true if the EvergreenProxy variable is set
+    #>
+    [CmdletBinding(SupportsShouldProcess = $False)]
+    param (
+        [Parameter(Mandatory = $False)]
+        [System.Management.Automation.SwitchParameter] $Creds
+    )
+
+    begin {}
+    process {
+        if ($PSBoundParameters.ContainsKey("Creds")) {
+            Test-Path -Path "Variable:EvergreenProxyCreds"
+        }
+        else {
+            Test-Path -Path "Variable:EvergreenProxy"
+        }
+    }
+}

--- a/Evergreen/Public/Get-EvergreenApp.ps1
+++ b/Evergreen/Public/Get-EvergreenApp.ps1
@@ -62,23 +62,23 @@ Function Get-EvergreenApp {
             try {
                 # Run the function to grab the application details; pass the per-app manifest to the app function
                 # Application manifests are located under Evergreen/Manifests
+                $params = @{
+                    res = (Get-FunctionResource -AppName $Name)
+                }
                 if ($PSBoundParameters.ContainsKey("AppParams")) {
                     Write-Verbose -Message "Adding AppParams."
-                    $params = @{
-                        res = (Get-FunctionResource -AppName $Name)
-                    }
                     $params += $AppParams
-                }
-                else {
-                    $params = @{
-                        res = (Get-FunctionResource -AppName $Name)
-                    }
                 }
                 Write-Verbose -Message "Calling: Get-$Name."
                 $Output = & Get-$Name @params
             }
             catch {
                 Write-Error -Message "Internal application function: $Function, failed with error: $($_.Exception.Message)"
+            }
+            finally {
+                if ($PSBoundParameters.ContainsKey("Proxy")) {
+                    Remove-ProxyEnv
+                }
             }
 
             # if we get an object, return it to the pipeline

--- a/Evergreen/Public/Get-EvergreenApp.ps1
+++ b/Evergreen/Public/Get-EvergreenApp.ps1
@@ -32,9 +32,10 @@ Function Get-EvergreenApp {
     begin {
         if ($PSBoundParameters.ContainsKey("Proxy")) {
             Set-ProxyEnv -Proxy $Proxy
-        }
-        if ($PSBoundParameters.ContainsKey("ProxyCredential")) {
-            Set-ProxyEnv -ProxyCredential $ProxyCredential
+
+            if ($PSBoundParameters.ContainsKey("ProxyCredential")) {
+                Set-ProxyEnv -ProxyCredential $ProxyCredential
+            }
         }
     }
 

--- a/Evergreen/Public/Get-EvergreenApp.ps1
+++ b/Evergreen/Public/Get-EvergreenApp.ps1
@@ -19,8 +19,24 @@ Function Get-EvergreenApp {
             Mandatory = $False,
             Position = 1,
             HelpMessage = "Specify a hashtable of parameters to pass to the internal application function.")]
-        [System.Collections.Hashtable] $AppParams
+        [System.Collections.Hashtable] $AppParams,
+
+        [Parameter(Mandatory = $False, Position = 2)]
+        [System.String] $Proxy,
+
+        [Parameter(Mandatory = $False, Position = 3)]
+        [System.Management.Automation.PSCredential]
+        $ProxyCredential = [System.Management.Automation.PSCredential]::Empty
     )
+
+    begin {
+        if ($PSBoundParameters.ContainsKey("Proxy")) {
+            Set-ProxyEnv -Proxy $Proxy
+        }
+        if ($PSBoundParameters.ContainsKey("ProxyCredential")) {
+            Set-ProxyEnv -ProxyCredential $ProxyCredential
+        }
+    }
 
     process {
         # Build a path to the application function

--- a/Evergreen/Public/Invoke-EvergreenLibraryUpdate.ps1
+++ b/Evergreen/Public/Invoke-EvergreenLibraryUpdate.ps1
@@ -22,12 +22,12 @@ function Invoke-EvergreenLibraryUpdate {
     )
 
     begin {
+        $params = @{}
         if ($PSBoundParameters.ContainsKey("Proxy")) {
-            Set-ProxyEnv -Proxy $Proxy
-
-            if ($PSBoundParameters.ContainsKey("ProxyCredential")) {
-                Set-ProxyEnv -ProxyCredential $ProxyCredential
-            }
+            $params.Proxy = $Proxy
+        }
+        if ($PSBoundParameters.ContainsKey("ProxyCredential")) {
+            $params.ProxyCredential = $ProxyCredential
         }
     }
 
@@ -61,7 +61,7 @@ function Invoke-EvergreenLibraryUpdate {
                     }
 
                     # Gather the application version information from Get-EvergreenApp
-                    $App = Get-EvergreenApp -Name $Application.EvergreenApp | Where-Object $WhereBlock
+                    $App = Get-EvergreenApp -Name $Application.EvergreenApp @params | Where-Object $WhereBlock
 
                     # If something returned, add to the library
                     if ($Null -ne $App) {
@@ -69,7 +69,7 @@ function Invoke-EvergreenLibraryUpdate {
 
                         # Save the installers to the library
                         if ($PSCmdlet.ShouldProcess("Downloading $($App.Count) application installers.", "Save-EvergreenApp")) {
-                            $Saved = $App | Save-EvergreenApp -Path $AppPath
+                            $Saved = $App | Save-EvergreenApp -Path $AppPath @params
                         }
 
                         # Add the saved installer path to the application version information

--- a/Evergreen/Public/Invoke-EvergreenLibraryUpdate.ps1
+++ b/Evergreen/Public/Invoke-EvergreenLibraryUpdate.ps1
@@ -11,10 +11,24 @@ function Invoke-EvergreenLibraryUpdate {
             HelpMessage = "Specify the path to the library.",
             ParameterSetName = "Path")]
         [ValidateNotNull()]
-        [System.IO.FileInfo] $Path
+        [System.IO.FileInfo] $Path,
+
+        [Parameter(Mandatory = $False, Position = 1)]
+        [System.String] $Proxy,
+
+        [Parameter(Mandatory = $False, Position = 2)]
+        [System.Management.Automation.PSCredential]
+        $ProxyCredential = [System.Management.Automation.PSCredential]::Empty
     )
 
-    begin {}
+    begin {
+        if ($PSBoundParameters.ContainsKey("Proxy")) {
+            Set-ProxyEnv -Proxy $Proxy
+        }
+        if ($PSBoundParameters.ContainsKey("ProxyCredential")) {
+            Set-ProxyEnv -ProxyCredential $ProxyCredential
+        }
+    }
 
     process {
 

--- a/Evergreen/Public/Invoke-EvergreenLibraryUpdate.ps1
+++ b/Evergreen/Public/Invoke-EvergreenLibraryUpdate.ps1
@@ -24,9 +24,10 @@ function Invoke-EvergreenLibraryUpdate {
     begin {
         if ($PSBoundParameters.ContainsKey("Proxy")) {
             Set-ProxyEnv -Proxy $Proxy
-        }
-        if ($PSBoundParameters.ContainsKey("ProxyCredential")) {
-            Set-ProxyEnv -ProxyCredential $ProxyCredential
+
+            if ($PSBoundParameters.ContainsKey("ProxyCredential")) {
+                Set-ProxyEnv -ProxyCredential $ProxyCredential
+            }
         }
     }
 


### PR DESCRIPTION
Enables proxy server support for the following functions
* `Get-EvergreenApp`
* `Save-EvergreenApp`
* `Invoke-EvergreenLibraryUpdate`

Adds `-Proxy` and `-ProxyCredential` arguments. `Get-EvergreenApp` sets an environment variable for the proxy server address and credential for use by internal app and private functions.

`Save-EvergreenApp` and `Invoke-EvergreenLibraryUpdate` either use these parameters directly or pass the parameters to other functions