### PR TITLE
Microsoft Terminal: Adding app

### DIFF
--- a/Evergreen/Apps/Get-MicrosoftTerminal.ps1
+++ b/Evergreen/Apps/Get-MicrosoftTerminal.ps1
@@ -1,0 +1,26 @@
+Function Get-MicrosoftTerminal {
+    <#
+        .SYNOPSIS
+            Returns the available Microsoft Terminal versions.
+
+        .NOTES
+            Author: Kirill Trofimov
+    #>
+    [OutputType([System.Management.Automation.PSObject])]
+    [CmdletBinding(SupportsShouldProcess = $False)]
+    param (
+        [Parameter(Mandatory = $False, Position = 0)]
+        [ValidateNotNull()]
+        [System.Management.Automation.PSObject]
+        $res = (Get-FunctionResource -AppName ("$($MyInvocation.MyCommand)".Split("-"))[1])
+    )
+
+    # Pass the repo releases API URL and return a formatted object
+    $params = @{
+        Uri          = $res.Get.Uri
+        MatchVersion = $res.Get.MatchVersion
+        Filter       = $res.Get.MatchFileTypes
+    }
+    $object = Get-GitHubRepoRelease @params
+    Write-Output -InputObject $object
+}

--- a/Evergreen/Manifests/MicrosoftTerminal.json
+++ b/Evergreen/Manifests/MicrosoftTerminal.json
@@ -1,0 +1,23 @@
+{
+	"Name": "Microsoft Terminal",
+	"Source": "https://github.com/microsoft/terminal/",
+	"Get": {
+		"Uri": "https://api.github.com/repos/microsoft/terminal/releases/latest",
+		"MatchVersion": "(\\d+(\\.\\d+){1,4}).*",
+		"MatchFileTypes": "\\.msixbundle$"
+	},
+	"Install": {
+		"Setup": "",
+		"Preinstall": "",
+		"Physical": {
+			"Arguments": "",
+			"PostInstall": [
+			]
+		},
+		"Virtual": {
+			"Arguments": "",
+			"PostInstall": [
+			]
+		}
+	}
+}


### PR DESCRIPTION
Hello, another app for Evergreen - Microsoft Terminal:
* https://github.com/microsoft/terminal/

One point - it's possible to download only *.msixbundle files, as this app is builded for Microsoft Store. Currently they provide versions for Win10&Win11:

```Powershell
PS C:\Users\g3rhard> Get-EvergreenApp -Name MicrosoftTerminal

Version      : 1.15.2874.0
Platform     : Windows
Architecture : x86
Type         : msixbundle
Date         : 2022-10-14T23:56:30Z
Size         : 18284690
URI          : https://github.com/microsoft/terminal/releases/download/v1.15.2874.0/Microsoft.WindowsT
               erminal_Win11_1.15.2875.0_8wekyb3d8bbwe.msixbundle

Version      : 1.15.2874.0
Platform     : Windows
Architecture : x86
Date         : 2022-10-14T23:56:30Z
Size         : 38563260
URI          : https://github.com/microsoft/terminal/releases/download/v1.15.2874.0/Microsoft.WindowsT
               erminal_Win10_1.15.2874.0_8wekyb3d8bbwe.msixbundle
```