### PR TITLE
AWS CLI: Adding app

### DIFF
--- a/Evergreen/Apps/Get-AWSCLI.ps1
+++ b/Evergreen/Apps/Get-AWSCLI.ps1
@@ -1,0 +1,41 @@
+Function Get-AWSCLI {
+    <#
+        .SYNOPSIS
+            Get the current versions and download URLs for AWS CLI
+
+        .NOTES
+            Author: Kirill Trofimov
+    #>
+    [OutputType([System.Management.Automation.PSObject])]
+    [CmdletBinding(SupportsShouldProcess = $False)]
+    param (
+        [Parameter(Mandatory = $False, Position = 0)]
+        [ValidateNotNull()]
+        [System.Management.Automation.PSObject]
+        $res = (Get-FunctionResource -AppName ("$($MyInvocation.MyCommand)".Split("-"))[1])
+    )
+
+    # Get the latest download
+    ForEach ($CLIversion in $res.Get.Download.CLI.GetEnumerator()) {
+        Write-Verbose -Message "$($MyInvocation.MyCommand): Looking for CLI version $($CLIversion.Name)."
+
+        ForEach ($CLIType in $res.Get.Download.CLI.($CLIversion.Name).GetEnumerator()) {
+
+            $Url = $CLIType.Value
+            $Response = Resolve-SystemNetWebRequest -Uri $Url
+
+            # Construct the output; Return the custom object to the pipeline
+            #NOTE: Version can now be returned with `Get-GitHubRepoRelease -ReturnVersionOnly`
+            If ($Null -ne $Response) {
+                $PSObject = [PSCustomObject] @{
+                    Version      = [RegEx]::Match($Response.ResponseUri.LocalPath, $res.Get.Download.MatchVersion).Captures.Groups[1].Value
+                    Architecture = Get-Architecture -String $Url
+                    CLI          = $CLIversion.Name
+                    Type         = [System.IO.Path]::GetExtension($Url).Split(".")[-1]
+                    URI          = $Response.ResponseUri.AbsoluteUri
+                }
+                Write-Output -InputObject $PSObject
+            }
+        }
+    }
+}

--- a/Evergreen/Manifests/AWSCLI.json
+++ b/Evergreen/Manifests/AWSCLI.json
@@ -3,28 +3,23 @@
 	"Source": "https://github.com/aws/aws-cli/",
 	"Get": {
 		"Update": {
-			"Uri": ""
+			"Uri": "https://api.github.com/repos/aws/aws-cli/tags",
+            "ContentType": "application/json; charset=utf-8",
+			"MatchVersion": "(\\d+(\\.\\d+){1,3}).*"
 		},
 		"Download": {
-			"CLI": {
-				"2": {
-					"x64msi" :"https://awscli.amazonaws.com/AWSCLIV2.msi"
-				},
-				"1": {
-					"x64msi" :"https://s3.amazonaws.com/aws-cli/AWSCLI64PY3.msi",
-					"x86msi" :"https://s3.amazonaws.com/aws-cli/AWSCLI32PY3.msi"
-				}
-			}
+			"Uri" :"https://awscli.amazonaws.com/AWSCLIV2-#version.msi",
+			"ReplaceText": "#version"
 		}
 	},
 	"Install": {
-		"Setup": "AWSCLI*.msi",
+		"Setup": "AWSCLIV2-*.msi",
 		"Physical": {
-			"Arguments": "/install /passive /norestart",
+			"Arguments": "/quiet /norestart",
 			"PostInstall": []
 		},
 		"Virtual": {
-			"Arguments": "/install /passive /norestart",
+			"Arguments": "/quiet /norestart",
 			"PostInstall": []
 		}
 	}

--- a/Evergreen/Manifests/AWSCLI.json
+++ b/Evergreen/Manifests/AWSCLI.json
@@ -1,0 +1,31 @@
+{
+	"Name": "AWS CLI",
+	"Source": "https://github.com/aws/aws-cli/",
+	"Get": {
+		"Update": {
+			"Uri": ""
+		},
+		"Download": {
+			"CLI": {
+				"2": {
+					"x64msi" :"https://awscli.amazonaws.com/AWSCLIV2.msi"
+				},
+				"1": {
+					"x64msi" :"https://s3.amazonaws.com/aws-cli/AWSCLI64PY3.msi",
+					"x86msi" :"https://s3.amazonaws.com/aws-cli/AWSCLI32PY3.msi"
+				}
+			}
+		}
+	},
+	"Install": {
+		"Setup": "AWSCLI*.msi",
+		"Physical": {
+			"Arguments": "/install /passive /norestart",
+			"PostInstall": []
+		},
+		"Virtual": {
+			"Arguments": "/install /passive /norestart",
+			"PostInstall": []
+		}
+	}
+}


### PR DESCRIPTION
Hello, another app for Evergreen - AWS CLI

Links:
* https://api.github.com/repos/aws/aws-cli/tags
* https://docs.aws.amazon.com/cli/latest/userguide/getting-started-version.html

  ```
  https://awscli.amazonaws.com/AWSCLIV2-version.number.msi
  ```

[7f6e22d](https://github.com/aaronparker/evergreen/commit/7f6e22dd8c562dc4da4187d8e8653b1c783f6c71) First commit (without versioning, only latest versions for AWS CLI v1/v2). I've tried the same things, as with Amazon Corretto - but headers aren't the same.

```Powershell
PS C:\Users\g3rhard> Get-EvergreenApp -Name AWSCLI -Verbose
VERBOSE: Function path: C:\Users\g3rhard\Projects\_powershell_modules\Evergreen\Apps\Get-AWSCLI.ps1
VERBOSE: Function exists: C:\Users\g3rhard\Projects\_powershell_modules\Evergreen\Apps\Get-AWSCLI.ps1.
VERBOSE: Dot sourcing: C:\Users\g3rhard\Projects\_powershell_modules\Evergreen\Apps\Get-AWSCLI.ps1.
VERBOSE: Get-FunctionResource: read application resource strings from
[C:\Users\g3rhard\Projects\_powershell_modules\Evergreen\Manifests\AWSCLI.json]
VERBOSE: Calling: Get-AWSCLI.
VERBOSE: Get-AWSCLI: Looking for CLI version 2.
VERBOSE: Resolve-SystemNetWebRequest: Attempting to resolve:
https://awscli.amazonaws.com/AWSCLIV2.msi.
VERBOSE: Resolve-SystemNetWebRequest: Response: [OK].
VERBOSE: Resolve-SystemNetWebRequest: Resolved to: [https://awscli.amazonaws.com/AWSCLIV2.msi].
VERBOSE: Get-Architecture: Architecture not found in https://awscli.amazonaws.com/AWSCLIV2.msi,
defaulting to x86.
VERBOSE: Get-AWSCLI: Looking for CLI version 1.
VERBOSE: Resolve-SystemNetWebRequest: Attempting to resolve:
https://s3.amazonaws.com/aws-cli/AWSCLI32PY3.msi.
VERBOSE: Resolve-SystemNetWebRequest: Response: [OK].
VERBOSE: Resolve-SystemNetWebRequest: Resolved to: [https://s3.amazonaws.com/aws-cli/AWSCLI32PY3.msi].
VERBOSE: Get-Architecture: Architecture not found in https://s3.amazonaws.com/aws-cli/AWSCLI32PY3.msi,
 defaulting to x86.
VERBOSE: Resolve-SystemNetWebRequest: Attempting to resolve:
https://s3.amazonaws.com/aws-cli/AWSCLI64PY3.msi.
VERBOSE: Resolve-SystemNetWebRequest: Response: [OK].
VERBOSE: Resolve-SystemNetWebRequest: Resolved to: [https://s3.amazonaws.com/aws-cli/AWSCLI64PY3.msi].
VERBOSE: Get-Architecture: Architecture not found in https://s3.amazonaws.com/aws-cli/AWSCLI64PY3.msi,
 defaulting to x86.
VERBOSE: Performing the operation "Return output" on target
"C:\Users\g3rhard\Projects\_powershell_modules\Evergreen\Apps\Get-AWSCLI.ps1".
VERBOSE: Output result from:
C:\Users\g3rhard\Projects\_powershell_modules\Evergreen\Apps\Get-AWSCLI.ps1.


Version      :
Architecture : x86
CLI          : 1
Type         : msi
URI          : https://s3.amazonaws.com/aws-cli/AWSCLI64PY3.msi

Version      :
Architecture : x86
CLI          : 1
Type         : msi
URI          : https://s3.amazonaws.com/aws-cli/AWSCLI32PY3.msi

Version      :
Architecture : x86
CLI          : 2
Type         : msi
URI          : https://awscli.amazonaws.com/AWSCLIV2.msi     
```

Last commit [8f99d7d](https://github.com/aaronparker/evergreen/commit/8f99d7d4f3fb1243d3b621bd80c4f8cbbc5053e8):
```Powershell
PS C:\Users\TROFIKI> Get-EvergreenApp -Name AWSCLI

Version URI
------- ---
2.8.12  https://awscli.amazonaws.com/AWSCLIV2-2.8.12.msi
2.8.11  https://awscli.amazonaws.com/AWSCLIV2-2.8.11.msi
2.8.9   https://awscli.amazonaws.com/AWSCLIV2-2.8.9.msi
2.8.8   https://awscli.amazonaws.com/AWSCLIV2-2.8.8.msi
2.8.7   https://awscli.amazonaws.com/AWSCLIV2-2.8.7.msi
2.8.6   https://awscli.amazonaws.com/AWSCLIV2-2.8.6.msi
2.8.5   https://awscli.amazonaws.com/AWSCLIV2-2.8.5.msi
2.8.4   https://awscli.amazonaws.com/AWSCLIV2-2.8.4.msi
2.8.3   https://awscli.amazonaws.com/AWSCLIV2-2.8.3.msi
2.8.2   https://awscli.amazonaws.com/AWSCLIV2-2.8.2.msi
```

As for me - second option is much better, because now everyone use only V2 of aws cli.