### PR TITLE
Yubico Authenticator: Adding app

### DIFF
--- a/Evergreen/Apps/Get-YubicoAuthenticator.ps1
+++ b/Evergreen/Apps/Get-YubicoAuthenticator.ps1
@@ -1,0 +1,30 @@
+Function Get-YubicoAuthenticator {
+    <#
+        .SYNOPSIS
+            Returns the available Yubico Authenticator versions.
+
+        .NOTES
+            Author: Kirill Trofimov
+    #>
+    [OutputType([System.Management.Automation.PSObject])]
+    [CmdletBinding(SupportsShouldProcess = $False)]
+    param (
+        [Parameter(Mandatory = $False, Position = 0)]
+        [ValidateNotNull()]
+        [System.Management.Automation.PSObject]
+        $res = (Get-FunctionResource -AppName ("$($MyInvocation.MyCommand)".Split("-"))[1])
+    )
+
+    # Pass the repo releases API URL and return a formatted object
+    $params = @{
+        Uri          = $res.Get.Uri
+        MatchVersion = $res.Get.MatchVersion
+        Filter       = $res.Get.MatchFileTypes
+    }
+    $object = Get-GitHubRepoRelease @params
+
+    # Get all builds, based on $LatestRelease version
+    $LatestRelease = $object | Select-Object -First 1
+    $Release = $object | Where-Object { $_.Version -match "$($LatestRelease.Version)" }
+    Write-Output -InputObject $Release
+}

--- a/Evergreen/Manifests/YubicoAuthenticator.json
+++ b/Evergreen/Manifests/YubicoAuthenticator.json
@@ -1,0 +1,23 @@
+{
+	"Name": "Yubico Authenticator",
+	"Source": "https://github.com/Yubico/yubioath-flutter/",
+	"Get": {
+		"Uri": "https://api.github.com/repos/Yubico/yubioath-flutter/releases",
+		"MatchVersion": "(\\d+(\\.\\d+){1,4}).*",
+		"MatchFileTypes": "\\.msi$"
+	},
+	"Install": {
+		"Setup": "yubico-authenticator-*.msi",
+		"Preinstall": "",
+		"Physical": {
+			"Arguments": "",
+			"PostInstall": [
+			]
+		},
+		"Virtual": {
+			"Arguments": "",
+			"PostInstall": [
+			]
+		}
+	}
+}


### PR DESCRIPTION
Hello, another app for Evergreen - Yubico Authenticator for Desktop:
* https://github.com/Yubico/yubioath-flutter
* https://developers.yubico.com/yubioath-flutter

For some reasons, they don't put all builds to the latest release, so I decided pull from GitHub API all releases and grab the latest one, based on existence of Windows package:
```json
"Uri": "https://api.github.com/repos/Yubico/yubioath-flutter/releases",
```
```Powershell
$object = Get-GitHubRepoRelease @params

# Get all builds, based on $LatestRelease version
$LatestRelease = $object | Select-Object -First 1
$Release = $object | Where-Object { $_.Version -match "$($LatestRelease.Version)" }
Write-Output -InputObject $Release
```

Results:
```Powershell
PS C:\Users\g3rhard> Get-EvergreenApp -Name YubicoAuthenticator

Version      : 6.0.0
Platform     : Windows
Architecture : x64
Type         : msi
Date         : 2022-11-09T12:37:32Z
Size         : 46379008
URI          : https://github.com/Yubico/yubioath-flutter/releases/download/6.0.0/yubico-authenticator-6.0.0-win64.msi
```