### PR TITLE
Docker Desktop: Update with a few releases in release URL

### DIFF
--- a/Evergreen/Apps/Get-DockerDesktop.ps1
+++ b/Evergreen/Apps/Get-DockerDesktop.ps1
@@ -16,15 +16,19 @@ Function Get-DockerDesktop {
         $res = (Get-FunctionResource -AppName ("$($MyInvocation.MyCommand)".Split("-"))[1])
     )
 
-    $Update = Invoke-RestMethodWrapper -Uri $res.Get.Update.Uri
-    if ($Null -ne $Update) {
-        $PSObject = [PSCustomObject] @{
-            Version = $Update.enclosure.shortVersionString
-            Build   = $Update.enclosure.version
-            Size    = $Update.enclosure.length
-            Type    = Get-FileType -File $($Update.enclosure.url | Where-Object { $_ -match "\.msi$" } | Select-Object -First 1)
-            URI     = $Update.enclosure.url | Where-Object { $_ -match "\.msi$" } | Select-Object -First 1
+    $Updates = Invoke-RestMethodWrapper -Uri $res.Get.Update.Uri
+
+    foreach ($Update in $Updates) {
+        if ($Null -ne $Update) {
+            $PSObject = [PSCustomObject] @{
+                Version = $Update.enclosure.shortVersionString
+                Build   = $Update.enclosure.version
+                Size    = $Update.enclosure.length
+                Type    = Get-FileType -File $($Update.enclosure.url | Where-Object { $_ -match "\.exe$" } | Select-Object -First 1)
+                URI     = $Update.enclosure.url | Where-Object { $_ -match "\.exe$" } | Select-Object -First 1
+            }
+            Write-Output -InputObject $PSObject
         }
-        Write-Output -InputObject $PSObject
     }
+
 }


### PR DESCRIPTION
Hello, there is update for Docker Desktop, previously I got this output:

```Powershell
PS C:\Users\g3rhard Get-EvergreenApp -Name "DockerDesktop"

Version : {4.13.1, 4.14.1}
Build   : {90346, 91661}
Size    : 2
Type    : msi                                                                                                                 /appcast.xml
URI     : https://desktop.docker.com/win/main/amd64/90346/DockerDesktop.msi         
```

Not looks like correct output - looks like array comes from URL, so I decided to put in foreach, and after it looks like this:

```Powershell
PS C:\Users\g3rhard> Get-EvergreenApp -Name "DockerDesktop" | Select -First 1

Version : 4.14.1
Build   : 91661
Size    : 591753040
Type    : exe
URI     : https://desktop.docker.com/win/main/amd64/91661/Docker%20Desktop%20Installer.exe

PS C:\Users\g3rhard> Get-EvergreenApp -Name "DockerDesktop" | Select -First 1 | Save-EvergreenApp -Path C:\Temp\installer.exe

    Directory: C:\Temp\installer.exe\4.14.1

Mode                 LastWriteTime         Length Name
----                 -------------         ------ ----
-a---          11/29/2022 11:44 AM      591753040 Docker%20Desktop%20Installer.exe
```

Another point - it's not possible to download MSI package due to http 403 error, so I switched it to EXE:

```Powershell
PS C:\Users\g3rhard> Get-EvergreenApp -Name "DockerDesktop" | Select -First 1 | Save-EvergreenApp -Path C:\Temp\installer.msi
Save-EvergreenApp: Download failed: https://desktop.docker.com/win/main/amd64/91661/DockerDesktop.msi
Save-EvergreenApp: Error: Response status code does not indicate success: 403 (Forbidden).
```