### PR TITLE
Proposed fix for #445

### DIFF
--- a/Evergreen/Apps/Get-OBSStudio.ps1
+++ b/Evergreen/Apps/Get-OBSStudio.ps1
@@ -29,7 +29,12 @@
         ForEach ($Update in $Updates) {
 
             # Build the latest version number
-            $Version = "$($Update.version_major).$($Update.version_minor).$($Update.version_patch)"
+            If ($Update.version_patch -eq 0) {
+                # Handle edge case where binaries with version_patch of 0 are published with only major.minor version
+                $Version = "$($Update.version_major).$($Update.version_minor)"
+            } else {
+                $Version = "$($Update.version_major).$($Update.version_minor).$($Update.version_patch)"
+            }
 
             # Build the output object
             ForEach ($Architecture in $res.Get.Download.Architectures) {

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -11,7 +11,7 @@ repo_url: https://github.com/aaronparker/evergreen
 edit_uri: ""
 
 # Copyright
-copyright: Copyright &copy; 2022 Aaron Parker
+copyright: Copyright &copy; 2023 Aaron Parker
 
 # Configuration
 theme:


### PR DESCRIPTION
Handle edge case where OBS Studio binaries with version_patch of 0 are published with only major.minor version. 
Fixes #445