### PR TITLE
OBS Studio - Remove x86 as no longer available

### DIFF
--- a/Evergreen/Manifests/OBSStudio.json
+++ b/Evergreen/Manifests/OBSStudio.json
@@ -15,8 +15,7 @@
             "Uri": "https://cdn-fastly.obsproject.com/downloads/#FileName",
             "FileName": "OBS-Studio-#Version-Full-Installer-#Architecture.exe",
             "Architectures": [
-                "x64",
-                "x86"
+                "x64"
             ],
             "ReplaceText": {
                 "Version": "#Version",


### PR DESCRIPTION
As discussed in #445 remove x86 architecture from manifest as no longer available. 

Considered as "least restrictive" option making it easy to add back if x86 becomes available again or if another architecture is added e.g ARM. Downside is leaves currently unneeded `ForEach` loop in `Get-OBSStudio.ps1`