### PR TITLE
AWS CLI: Fix algorithm to find the latest version

### DIFF
--- a/Evergreen/Apps/Get-AWSCLI.ps1
+++ b/Evergreen/Apps/Get-AWSCLI.ps1
@@ -23,7 +23,7 @@ function Get-AWSCLI {
     }
 
     # Get only latest version tag from GitHub API
-    $Content = ((Invoke-WebRequestWrapper @params | ConvertFrom-Json).name | ForEach-Object { New-Object System.Version ($_) } | Sort-Object -Descending | Select-Object -First 1 | ForEach-Object {("{0}.{1}.{2}" -f $_.Major,$_.Minor,$_.Build)})
+    $Content = ((Invoke-WebRequestWrapper @params | ConvertFrom-Json).name | ForEach-Object { New-Object -TypeName "System.Version" ($_) } | Sort-Object -Descending | Select-Object -First 1 | ForEach-Object {("{0}.{1}.{2}" -f $_.Major,$_.Minor,$_.Build)})
 
     if ($null -ne $Content) {
         $Content | ForEach-Object {

--- a/Evergreen/Apps/Get-AWSCLI.ps1
+++ b/Evergreen/Apps/Get-AWSCLI.ps1
@@ -21,14 +21,16 @@ function Get-AWSCLI {
         ContentType  = $res.Get.Update.ContentType
         ReturnObject = "Content"
     }
-    $Content = Invoke-WebRequestWrapper @params | ConvertFrom-Json
+
+    # Get only latest version tag from GitHub API
+    $Content = ((Invoke-WebRequestWrapper @params | ConvertFrom-Json).name | %{ new-object System.Version ($_) } | Sort-Object -Descending | Select-Object -First 1 | % {("{0}.{1}.{2}" -f $_.Major,$_.Minor,$_.Build)})
 
     if ($null -ne $Content) {
-        $Content | Sort-Object -Property "name" | Select-Object -Last 1 | ForEach-Object {
+        $Content | ForEach-Object {
             $PSObject = [PSCustomObject] @{
-                Version = $_.name
-                Type    = Get-FileType -File $res.Get.Download.Uri
-                URI     = $res.Get.Download.Uri -replace $res.Get.Download.ReplaceText, $_.name
+                Version = $_
+                Type    = "msi"
+                URI     = $res.Get.Download.Uri -replace $res.Get.Download.ReplaceText, $_
             }
             Write-Output -InputObject $PSObject
         }

--- a/Evergreen/Apps/Get-AWSCLI.ps1
+++ b/Evergreen/Apps/Get-AWSCLI.ps1
@@ -23,7 +23,7 @@ function Get-AWSCLI {
     }
 
     # Get only latest version tag from GitHub API
-    $Content = ((Invoke-WebRequestWrapper @params | ConvertFrom-Json).name | %{ new-object System.Version ($_) } | Sort-Object -Descending | Select-Object -First 1 | % {("{0}.{1}.{2}" -f $_.Major,$_.Minor,$_.Build)})
+    $Content = ((Invoke-WebRequestWrapper @params | ConvertFrom-Json).name | ForEach-Object { New-Object System.Version ($_) } | Sort-Object -Descending | Select-Object -First 1 | ForEach-Object {("{0}.{1}.{2}" -f $_.Major,$_.Minor,$_.Build)})
 
     if ($null -ne $Content) {
         $Content | ForEach-Object {

--- a/Evergreen/Manifests/AWSCLI.json
+++ b/Evergreen/Manifests/AWSCLI.json
@@ -4,7 +4,7 @@
 	"Get": {
 		"Update": {
 			"Uri": "https://api.github.com/repos/aws/aws-cli/tags",
-            "ContentType": "application/json; charset=utf-8"
+			"ContentType": "application/json; charset=utf-8"
 		},
 		"Download": {
 			"Uri" :"https://awscli.amazonaws.com/AWSCLIV2-#version.msi",

--- a/Evergreen/Manifests/AWSCLI.json
+++ b/Evergreen/Manifests/AWSCLI.json
@@ -4,8 +4,7 @@
 	"Get": {
 		"Update": {
 			"Uri": "https://api.github.com/repos/aws/aws-cli/tags",
-            "ContentType": "application/json; charset=utf-8",
-			"MatchVersion": "(\\d+(\\.\\d+){1,3}).*"
+            "ContentType": "application/json; charset=utf-8"
 		},
 		"Download": {
 			"Uri" :"https://awscli.amazonaws.com/AWSCLIV2-#version.msi",


### PR DESCRIPTION
Hello, just found that I did a mistake in algorithm - it started always showing the wrong version, instead of latest one:

```
> Get-EvergreenApp -Name "AWSCLI"

Version Type URI                                            
------- ---- ---                                            
2.9.9   msi  https://awscli.amazonaws.com/AWSCLIV2-2.9.9.msi
```

After the changes it should be fine:

```
> Get-EvergreenApp -Name "AWSCLI"

Version Type URI                                             
------- ---- ---                                             
2.9.23  msi  https://awscli.amazonaws.com/AWSCLIV2-2.9.23.msi
```