### PR TITLE
Update VMwareWorkstationPlayer.json

### DIFF
--- a/Evergreen/Manifests/VMwareWorkstationPlayer.json
+++ b/Evergreen/Manifests/VMwareWorkstationPlayer.json
@@ -3,8 +3,8 @@
 	"Source": "https://www.vmware.com/products/workstation-player.html",
 	"Get": {
 		"Update": {
-			"Uri": "https://customerconnect.vmware.com/channel/public/api/v1.0/products/getDLGHeader?locale=en_US&downloadGroup=WKST-PLAYER-1621&productId=1039",
-			"File": "https://customerconnect.vmware.com/channel/public/api/v1.0/dlg/details?locale=en_US&downloadGroup=WKST-PLAYER-1621"
+			"Uri": "https://customerconnect.vmware.com/channel/public/api/v1.0/products/getDLGHeader?locale=en_US&downloadGroup=WKST-PLAYER-1701&productId=1377",
+			"File": "https://customerconnect.vmware.com/channel/public/api/v1.0/dlg/details?locale=en_US&downloadGroup=WKST-PLAYER-1701"
 		},
 		"Download": {
 			"Uri": "https://download3.vmware.com/software/player/file/#filename"


### PR DESCRIPTION
The current version of this file returns version 16.2.5 for VMware Workstation Player instead of the expected version 17.0.1 (as of the time of writing). Although I do not have the skills and experience to implement a fix for this issue, I have found that the following API can be used to obtain the correct version information:

[https://customerconnect.vmware.com/channel/public/api/v1.0/products/getProductHeader?locale=en_US&product=vmware_workstation_player&category=desktop_end_user_computing&version=14_0](https://customerconnect.vmware.com/channel/public/api/v1.0/products/getProductHeader?locale=en_US&product=vmware_workstation_player&category=desktop_end_user_computing&version=14_0)


This API returns the `version.ID` of "17_0" in JSON format ...
```
 "versions": [
    {
      "id": "17_0",
      "name": "17.0",
      "slugUrl": "./info/slug/desktop_end_user_computing/vmware_workstation_player/17_0",
      "isSelected": false
    },
```
... which can be used as the `version` parameter for the `getRelatedDLGList` function. For example:

[https://customerconnect.vmware.com/channel/public/api/v1.0/products/getRelatedDLGList?&category=desktop_end_user_computing&product=vmware_workstation_player&dlgType=PRODUCT_BINARY&version=17_0](https://customerconnect.vmware.com/channel/public/api/v1.0/products/getRelatedDLGList?&category=desktop_end_user_computing&product=vmware_workstation_player&dlgType=PRODUCT_BINARY&version=17_0)

Call the above getRelatedDLGList API call will return the "code" (e.g. `WKST-PLAYER-1701` ) and "productId" (e.g. `1377` ) needed to complete the update URI.

```
"dlgEditionsLists": [
    {
      "name": "VMware Workstation Player 17.0",
      "dlgList": [
        {
          "name": "VMware Workstation Player",
          "code": "WKST-PLAYER-1701",
          "releaseDate": "2023-02-02T08:00:00Z",
          "productId": "1377",
          "releasePackageId": "100675",
          "isFirmwareImage": 0,
          "orderId": 1
        }
      ],
      "orderId": 0
    }
  ]
```

I hope this helps.