### PR TITLE
Development

### DIFF
--- a/Evergreen/Apps/Get-MicrosoftWvdInfraAgent.ps1
+++ b/Evergreen/Apps/Get-MicrosoftWvdInfraAgent.ps1
@@ -1,4 +1,4 @@
-Function Get-MicrosoftWvdInfraAgent {
+function Get-MicrosoftWvdInfraAgent {
     <#
         .SYNOPSIS
             Get the current version and download URL for the Microsoft Windows Virtual Desktop Infrastructure agent.
@@ -34,10 +34,10 @@ Function Get-MicrosoftWvdInfraAgent {
             Version      = [RegEx]::Match($Content.'Content-Disposition', $res.Get.Download.MatchVersion).Captures.Value
             Architecture = Get-Architecture -String $Filename
             Date         = $Content.'Last-Modified'[0]
-            Size         = $Content.'Content-Length'[0]
             Filename     = $Filename
             URI          = $res.Get.Download.Uri
         }
+        #if ($null -ne $Content.'Content-Length') { $PSObject | Add-Member -Name 'Size' -Type "NoteProperty" -Value $Content.'Content-Length'[0] }
         Write-Output -InputObject $PSObject
     }
 }

--- a/Evergreen/Private/Get-Architecture.ps1
+++ b/Evergreen/Private/Get-Architecture.ps1
@@ -1,21 +1,41 @@
-function Get-InstallerType {
+function Get-Architecture {
     [OutputType([System.String])]
-    [CmdletBinding(SupportsShouldProcess = $false)]
+    [CmdletBinding(SupportsShouldProcess = $False)]
     param (
-        [Parameter(Mandatory = $true, Position = 0)]
-        #[ValidateNotNullOrEmpty()]
+        [Parameter(Mandatory = $True, Position = 0)]
         [System.String] $String
     )
 
     switch -Regex ($String.ToLower()) {
-        "user" { $Type = "User"; break }
-        "portable" { $Type = "Portable"; break }
-        "no-installer" { $Type = "Portable"; break }
-        "debug" { $Type = "Debug"; break }
+        "aarch64"   { $architecture = "ARM64"; break }
+        "amd64"     { $architecture = "AMD64"; break }
+        "arm64"     { $architecture = "ARM64"; break }
+        "arm32"     { $architecture = "ARM32"; break }
+        "arm"       { $architecture = "ARM32"; break }
+        "nt64"      { $architecture = "x64"; break }
+        "nt32"      { $architecture = "x86"; break }
+        "win64"     { $architecture = "x64"; break }
+        "win32"     { $architecture = "x86"; break }
+        "win-arm64" { $architecture = "ARM64"; break }
+        "win-x64"   { $architecture = "x64"; break }
+        "win-x86"   { $architecture = "x86"; break }
+        "x86_64"    { $architecture = "x64"; break }
+        "x64"       { $architecture = "x64"; break }
+        "w64"       { $architecture = "x64"; break }
+        "-64"       { $architecture = "x64"; break }
+        "64-bit"    { $architecture = "x64"; break }
+        "64bit"     { $architecture = "x64"; break }
+        "32-bit"    { $architecture = "x86"; break }
+        "32bit"     { $architecture = "x86"; break }
+        "x32"       { $architecture = "x86"; break }
+        "w32"       { $architecture = "x86"; break }
+        "-32"       { $architecture = "x86"; break }
+        "-x86"      { $architecture = "x86"; break }
+        "x86"       { $architecture = "x86"; break }
         default {
-            Write-Verbose -Message "$($MyInvocation.MyCommand): Installer type not found in $String, defaulting to 'Default'."
-            $Type = "Default"
+            Write-Verbose -Message "$($MyInvocation.MyCommand): Architecture not found in $String, defaulting to x86."
+            $architecture = "x86"
         }
     }
-    Write-Output -InputObject $Type
+    Write-Output -InputObject $architecture
 }

--- a/Evergreen/Private/Get-Architecture.ps1
+++ b/Evergreen/Private/Get-Architecture.ps1
@@ -1,42 +1,21 @@
-function Get-Architecture {
+function Get-InstallerType {
     [OutputType([System.String])]
-    [CmdletBinding(SupportsShouldProcess = $False)]
+    [CmdletBinding(SupportsShouldProcess = $false)]
     param (
-        [Parameter(Mandatory = $True, Position = 0)]
+        [Parameter(Mandatory = $true, Position = 0)]
         #[ValidateNotNullOrEmpty()]
         [System.String] $String
     )
 
     switch -Regex ($String.ToLower()) {
-        "aarch64" { $architecture = "ARM64"; break }
-        "amd64" { $architecture = "AMD64"; break }
-        "arm64" { $architecture = "ARM64"; break }
-        "arm32" { $architecture = "ARM32"; break }
-        "arm" { $architecture = "ARM32"; break }
-        "nt64" { $architecture = "x64"; break }
-        "nt32" { $architecture = "x86"; break }
-        "win64" { $architecture = "x64"; break }
-        "win32" { $architecture = "x86"; break }
-        "win-arm64" { $architecture = "ARM64"; break }
-        "win-x64" { $architecture = "x64"; break }
-        "win-x86" { $architecture = "x86"; break }
-        "x86_64" { $architecture = "x64"; break }
-        "x64" { $architecture = "x64"; break }
-        "w64" { $architecture = "x64"; break }
-        "-64" { $architecture = "x64"; break }
-        "64-bit" { $architecture = "x64"; break }
-        "64bit" { $architecture = "x64"; break }
-        "32-bit" { $architecture = "x86"; break }
-        "32bit" { $architecture = "x86"; break }
-        "x32" { $architecture = "x86"; break }
-        "w32" { $architecture = "x86"; break }
-        "-32" { $architecture = "x86"; break }
-        "-x86" { $architecture = "x86"; break }
-        "x86" { $architecture = "x86"; break }
+        "user" { $Type = "User"; break }
+        "portable" { $Type = "Portable"; break }
+        "no-installer" { $Type = "Portable"; break }
+        "debug" { $Type = "Debug"; break }
         default {
-            Write-Verbose -Message "$($MyInvocation.MyCommand): Architecture not found in $String, defaulting to x86."
-            $architecture = "x86"
+            Write-Verbose -Message "$($MyInvocation.MyCommand): Installer type not found in $String, defaulting to 'Default'."
+            $Type = "Default"
         }
     }
-    Write-Output -InputObject $architecture
+    Write-Output -InputObject $Type
 }

--- a/Evergreen/Private/Get-GitHubRepoRelease.ps1
+++ b/Evergreen/Private/Get-GitHubRepoRelease.ps1
@@ -177,13 +177,14 @@ function Get-GitHubRepoRelease {
 
                             # Build the output object
                             $PSObject = [PSCustomObject] @{
-                                Version      = $version
-                                Platform     = Get-Platform -String $asset.browser_download_url
-                                Architecture = Get-Architecture -String $asset.browser_download_url
-                                Type         = [System.IO.Path]::GetExtension($asset.browser_download_url).Split(".")[-1]
-                                Date         = ConvertTo-DateTime -DateTime $item.created_at -Pattern "MM/dd/yyyy HH:mm:ss"
-                                Size         = $asset.size
-                                URI          = $asset.browser_download_url
+                                Version       = $version
+                                Platform      = Get-Platform -String $asset.browser_download_url
+                                Architecture  = Get-Architecture -String $asset.browser_download_url
+                                Type          = [System.IO.Path]::GetExtension($asset.browser_download_url).Split(".")[-1]
+                                InstallerType = Get-InstallerType -String $asset.browser_download_url
+                                Date          = ConvertTo-DateTime -DateTime $item.created_at -Pattern "MM/dd/yyyy HH:mm:ss"
+                                Size          = $asset.size
+                                URI           = $asset.browser_download_url
                             }
                             if ($PSObject.Platform -eq "Windows") {
                                 Write-Output -InputObject $PSObject

--- a/Evergreen/Private/Get-InstallerType.ps1
+++ b/Evergreen/Private/Get-InstallerType.ps1
@@ -1,42 +1,20 @@
-function Get-Architecture {
+function Get-InstallerType {
     [OutputType([System.String])]
-    [CmdletBinding(SupportsShouldProcess = $False)]
+    [CmdletBinding(SupportsShouldProcess = $false)]
     param (
-        [Parameter(Mandatory = $True, Position = 0)]
-        #[ValidateNotNullOrEmpty()]
+        [Parameter(Mandatory = $true, Position = 0)]
         [System.String] $String
     )
 
     switch -Regex ($String.ToLower()) {
-        "aarch64" { $architecture = "ARM64"; break }
-        "amd64" { $architecture = "AMD64"; break }
-        "arm64" { $architecture = "ARM64"; break }
-        "arm32" { $architecture = "ARM32"; break }
-        "arm" { $architecture = "ARM32"; break }
-        "nt64" { $architecture = "x64"; break }
-        "nt32" { $architecture = "x86"; break }
-        "win64" { $architecture = "x64"; break }
-        "win32" { $architecture = "x86"; break }
-        "win-arm64" { $architecture = "ARM64"; break }
-        "win-x64" { $architecture = "x64"; break }
-        "win-x86" { $architecture = "x86"; break }
-        "x86_64" { $architecture = "x64"; break }
-        "x64" { $architecture = "x64"; break }
-        "w64" { $architecture = "x64"; break }
-        "-64" { $architecture = "x64"; break }
-        "64-bit" { $architecture = "x64"; break }
-        "64bit" { $architecture = "x64"; break }
-        "32-bit" { $architecture = "x86"; break }
-        "32bit" { $architecture = "x86"; break }
-        "x32" { $architecture = "x86"; break }
-        "w32" { $architecture = "x86"; break }
-        "-32" { $architecture = "x86"; break }
-        "-x86" { $architecture = "x86"; break }
-        "x86" { $architecture = "x86"; break }
+        "user"          { $Type = "User"; break }
+        "portable"      { $Type = "Portable"; break }
+        "no-installer"  { $Type = "Portable"; break }
+        "debug"         { $Type = "Debug"; break }
         default {
-            Write-Verbose -Message "$($MyInvocation.MyCommand): Architecture not found in $String, defaulting to x86."
-            $architecture = "x86"
+            Write-Verbose -Message "$($MyInvocation.MyCommand): Installer type not found in $String, defaulting to 'Default'."
+            $Type = "Default"
         }
     }
-    Write-Output -InputObject $architecture
+    Write-Output -InputObject $Type
 }

--- a/Evergreen/Private/Get-InstallerType.ps1
+++ b/Evergreen/Private/Get-InstallerType.ps1
@@ -1,0 +1,42 @@
+function Get-Architecture {
+    [OutputType([System.String])]
+    [CmdletBinding(SupportsShouldProcess = $False)]
+    param (
+        [Parameter(Mandatory = $True, Position = 0)]
+        #[ValidateNotNullOrEmpty()]
+        [System.String] $String
+    )
+
+    switch -Regex ($String.ToLower()) {
+        "aarch64" { $architecture = "ARM64"; break }
+        "amd64" { $architecture = "AMD64"; break }
+        "arm64" { $architecture = "ARM64"; break }
+        "arm32" { $architecture = "ARM32"; break }
+        "arm" { $architecture = "ARM32"; break }
+        "nt64" { $architecture = "x64"; break }
+        "nt32" { $architecture = "x86"; break }
+        "win64" { $architecture = "x64"; break }
+        "win32" { $architecture = "x86"; break }
+        "win-arm64" { $architecture = "ARM64"; break }
+        "win-x64" { $architecture = "x64"; break }
+        "win-x86" { $architecture = "x86"; break }
+        "x86_64" { $architecture = "x64"; break }
+        "x64" { $architecture = "x64"; break }
+        "w64" { $architecture = "x64"; break }
+        "-64" { $architecture = "x64"; break }
+        "64-bit" { $architecture = "x64"; break }
+        "64bit" { $architecture = "x64"; break }
+        "32-bit" { $architecture = "x86"; break }
+        "32bit" { $architecture = "x86"; break }
+        "x32" { $architecture = "x86"; break }
+        "w32" { $architecture = "x86"; break }
+        "-32" { $architecture = "x86"; break }
+        "-x86" { $architecture = "x86"; break }
+        "x86" { $architecture = "x86"; break }
+        default {
+            Write-Verbose -Message "$($MyInvocation.MyCommand): Architecture not found in $String, defaulting to x86."
+            $architecture = "x86"
+        }
+    }
+    Write-Output -InputObject $architecture
+}

--- a/Evergreen/Public/Export-EvergreenApp.ps1
+++ b/Evergreen/Public/Export-EvergreenApp.ps1
@@ -2,10 +2,10 @@ function Export-EvergreenApp {
     <#
         .EXTERNALHELP Evergreen-help.xml
     #>
-    [CmdletBinding(SupportsShouldProcess = $True)]
+    [CmdletBinding(SupportsShouldProcess = $true)]
     param (
         [Parameter(
-            Mandatory = $True,
+            Mandatory = $true,
             Position = 0,
             ValueFromPipeline,
             HelpMessage = "Pass an application object from Get-EvergreenApp.")]
@@ -13,7 +13,7 @@ function Export-EvergreenApp {
         [System.Array] $InputObject,
 
         [Parameter(
-            Mandatory = $True,
+            Mandatory = $true,
             Position = 1,
             ValueFromPipelineByPropertyName,
             HelpMessage = "Specify the path to the JSON file.",
@@ -22,18 +22,16 @@ function Export-EvergreenApp {
         [System.IO.FileInfo] $Path
     )
 
-    begin {}
-
     process {
         if (Test-Path -Path $Path) {
-            try {
-                # Add the new details to the existing file content
-                $Content = Get-Content -Path $Path -Verbose:$VerbosePreference | ConvertFrom-Json
-                $InputObject += $Content
+            # Add the new details to the existing file content
+            $params = @{
+                Path        = $Path
+                ErrorAction = "Stop"
+                Verbose     = $VerbosePreference
             }
-            catch {
-                throw $_
-            }
+            $Content = Get-Content @params | ConvertFrom-Json -ErrorAction "Stop"
+            $InputObject += $Content
         }
 
         # Sort the content and keep unique versions
@@ -43,8 +41,8 @@ function Export-EvergreenApp {
         $OutputObject = $InputObject | Select-Object -Unique -Property $Properties
 
         # Export the data to file
-        $OutputObject | Sort-Object -Property @{ Expression = { [System.Version]$_.Version }; Descending = $false } | `
-            ConvertTo-Json | `
+        $OutputObject | Sort-Object -Property @{ Expression = { [System.Version] $_.Version }; Descending = $false } -ErrorAction "SilentlyContinue" | `
+            ConvertTo-Json -ErrorAction "Stop" | `
             Out-File -FilePath $Path -Encoding "Utf8" -NoNewline -Verbose:$VerbosePreference
 
         if ($PSCmdlet.ShouldProcess($Path, "Output to pipeline")) {
@@ -54,6 +52,4 @@ function Export-EvergreenApp {
             Write-Output -InputObject $Output
         }
     }
-
-    end {}
 }

--- a/Evergreen/Public/Get-EvergreenLibraryApp.ps1
+++ b/Evergreen/Public/Get-EvergreenLibraryApp.ps1
@@ -23,9 +23,6 @@ function Get-EvergreenLibraryApp {
         [System.String] $Name
     )
 
-    begin {
-    }
-
     process {
         # Validate $Inventory has the required properties
         if ([System.Boolean]($Inventory.Inventory)) {
@@ -44,8 +41,5 @@ function Get-EvergreenLibraryApp {
         else {
             Write-Error -Message "Cannot find an application in the library that matches '$Name'"
         }
-    }
-
-    end {
     }
 }

--- a/Evergreen/Public/Invoke-EvergreenLibraryUpdate.ps1
+++ b/Evergreen/Public/Invoke-EvergreenLibraryUpdate.ps1
@@ -37,13 +37,7 @@ function Invoke-EvergreenLibraryUpdate {
 
             if (Test-Path -Path $LibraryFile) {
                 Write-Verbose -Message "Library exists: $LibraryFile."
-                try {
-                    $Library = Get-Content -Path $LibraryFile | ConvertFrom-Json
-                }
-                catch {
-                    Write-Error -Message "Encountered an error reading library $LibraryFile"
-                    throw $_
-                }
+                $Library = Get-Content -Path $LibraryFile -ErrorAction "Stop" | ConvertFrom-Json -ErrorAction "Stop"
 
                 foreach ($Application in $Library.Applications) {
 
@@ -100,6 +94,4 @@ function Invoke-EvergreenLibraryUpdate {
             throw [System.IO.DirectoryNotFoundException]::New($Msg)
         }
     }
-
-    end {}
 }

--- a/Evergreen/Public/New-EvergreenLibrary.ps1
+++ b/Evergreen/Public/New-EvergreenLibrary.ps1
@@ -23,13 +23,8 @@ function New-EvergreenLibrary {
     )
 
     begin {
-        try {
-            $LibraryJsonTemplate = [System.IO.Path]::Combine($MyInvocation.MyCommand.Module.ModuleBase, "EvergreenLibraryTemplate.json")
-            $Library = Get-Content -Path $LibraryJsonTemplate -Verbose:$VerbosePreference | ConvertFrom-Json
-        }
-        catch {
-            throw $_
-        }
+        $LibraryJsonTemplate = [System.IO.Path]::Combine($MyInvocation.MyCommand.Module.ModuleBase, "EvergreenLibraryTemplate.json")
+        $Library = Get-Content -Path $LibraryJsonTemplate  -ErrorAction "Stop" -Verbose:$VerbosePreference | ConvertFrom-Json -ErrorAction "Stop"
     }
 
     process {
@@ -38,21 +33,15 @@ function New-EvergreenLibrary {
             Write-Verbose -Message "Path exists: $Path."
         }
         else {
-            try {
-                $params = @{
-                    Path        = $Path
-                    ItemType    = "Container"
-                    ErrorAction = "SilentlyContinue"
-                    Verbose     = $VerbosePreference
-                }
-                Write-Verbose -Message "Path does not exist: $Path."
-                Write-Verbose -Message "Create: $Path."
-                New-Item @params | Out-Null
+            $params = @{
+                Path        = $Path
+                ItemType    = "Container"
+                ErrorAction = "Stop"
+                Verbose     = $VerbosePreference
             }
-            catch {
-                Write-Error -Message "Failed to create $Path"
-                throw $_
-            }
+            Write-Verbose -Message "Path does not exist: $Path."
+            Write-Verbose -Message "Create: $Path."
+            New-Item @params | Out-Null
         }
         #endregion
 
@@ -61,13 +50,8 @@ function New-EvergreenLibrary {
             Write-Verbose -Message "Library exists: $Path."
         }
         else {
-            try {
-                $Library.Name = $Name
-                $Library | ConvertTo-Json | Out-File -FilePath $LibraryFile -Encoding "Utf8" -NoNewline -Verbose:$VerbosePreference
-            }
-            catch {
-                throw $_
-            }
+            $Library.Name = $Name
+            $Library | ConvertTo-Json -ErrorAction "Stop" | Out-File -FilePath $LibraryFile -Encoding "Utf8" -NoNewline -ErrorAction "Stop" -Verbose:$VerbosePreference
         }
     }
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,14 @@
 
 ## VERSION
 
+* Fixes an issue with `MicrosoftWvdInfraAgent` where the source no longer returns the download size [#490](https://github.com/aaronparker/evergreen/issues/490)
+* Updates private function `GitHubRepoRelease` to return a new property `InstallerType` with values for `Portable`, `User`, or `Debug` based on the installer type. This property has a default value of `Default` where none of the other types are supported
+* Adds private function `Get-InstallerType` to determine the installer type
+* Fixes an issue with `Export-EvergreenApp` where the version property is not a proper version number [#491](https://github.com/aaronparker/evergreen/issues/491)
+* Some small code improvements in public functions
+
+## VERSION
+
 * Update `MicrosoftWvdMultimediaRedirection` to remove file size as value is not returned from Microsoft source
 
 ## 2304.791

--- a/tests/Private/Get-InstallerType.Tests.ps1
+++ b/tests/Private/Get-InstallerType.Tests.ps1
@@ -37,7 +37,7 @@ Describe -Name "Get-InstallerType" {
 
         It "Returns Debug given an debug URL" {
             InModuleScope -ModuleName "Evergreen" {
-                $Url = "https://github.com/microsoft/PowerToys/releases/download/v0.69.1/PowerToysPortableDEBUG-0.69.1-arm64.exe"
+                $Url = "https://github.com/microsoft/PowerToys/releases/download/v0.69.1/PowerToysDEBUG-0.69.1-arm64.exe"
                 Get-InstallerType -String $Url | Should -Be "Debug"
             }
         }

--- a/tests/Private/Get-InstallerType.Tests.ps1
+++ b/tests/Private/Get-InstallerType.Tests.ps1
@@ -1,0 +1,45 @@
+<#
+    .SYNOPSIS
+        Private Pester function tests.
+#>
+[OutputType()]
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseDeclaredVarsMoreThanAssignments", "", Justification="This OK for the tests files.")]
+param ()
+
+BeforeDiscovery {
+}
+
+BeforeAll {
+}
+
+Describe -Name "Get-InstallerType" {
+    Context "It returns expected output" {
+        It "Returns Default given a default URL" {
+            InModuleScope -ModuleName "Evergreen" {
+                $Url = "https://statics.teams.cdn.office.net/production-windows-x64/1.3.00.34662/Teams_windows_x64.msi"
+                Get-InstallerType -String $Url | Should -Be "Default"
+            }
+        }
+
+        It "Returns User given an User URL" {
+            InModuleScope -ModuleName "Evergreen" {
+                $Url = "https://github.com/microsoft/PowerToys/releases/download/v0.69.1/PowerToysUserSetup-0.69.1-arm64.exe"
+                Get-InstallerType -String $Url | Should -Be "User"
+            }
+        }
+
+        It "Returns Portable given an portable URL" {
+            InModuleScope -ModuleName "Evergreen" {
+                $Url = "https://github.com/microsoft/PowerToys/releases/download/v0.69.1/PowerToysPortableSetup-0.69.1-arm64.exe"
+                Get-InstallerType -String $Url | Should -Be "Portable"
+            }
+        }
+
+        It "Returns Debug given an debug URL" {
+            InModuleScope -ModuleName "Evergreen" {
+                $Url = "https://github.com/microsoft/PowerToys/releases/download/v0.69.1/PowerToysPortableDEBUG-0.69.1-arm64.exe"
+                Get-InstallerType -String $Url | Should -Be "Debug"
+            }
+        }
+    }
+}


### PR DESCRIPTION
* Fixes an issue with `MicrosoftWvdInfraAgent` where the source no longer returns the download size [#490](https://github.com/aaronparker/evergreen/issues/490)
* Updates private function `GitHubRepoRelease` to return a new property `InstallerType` with values for `Portable`, `User`, or `Debug` based on the installer type. This property has a default value of `Default` where none of the other types are supported
* Adds private function `Get-InstallerType` to determine the installer type
* Fixes an issue with `Export-EvergreenApp` where the version property is not a proper version number [#491](https://github.com/aaronparker/evergreen/issues/491)
* Some small code improvements in public functions