### PR TITLE
Development

### DIFF
--- a/.github/workflows/test-development.yml
+++ b/.github/workflows/test-development.yml
@@ -20,7 +20,7 @@ jobs:
       security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
       actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status
     name: Run PSScriptAnalyzer
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
     steps:
       - uses: actions/checkout@v3
 

--- a/Evergreen/Apps/Get-Anaconda.ps1
+++ b/Evergreen/Apps/Get-Anaconda.ps1
@@ -1,4 +1,4 @@
-Function Get-Anaconda {
+function Get-Anaconda {
     <#
         .SYNOPSIS
             Get the current version and download URL for Anaconda.
@@ -16,50 +16,44 @@ Function Get-Anaconda {
         $res = (Get-FunctionResource -AppName ("$($MyInvocation.MyCommand)".Split("-"))[1])
     )
 
-    # Construct the Anaconda repo uri
-    $Uri = $res.Get.Update.Uri -replace "#replace", $res.Get.Update.ReplaceFileList
     # Query the repo to get the full list of files
-    $updateFeed = Invoke-RestMethodWrapper -Uri $Uri
-
-    If ($Null -ne $updateFeed) {
+    $Uri = $res.Get.Update.Uri -replace "#replace", $res.Get.Update.ReplaceFileList
+    $UpdateFeed = Invoke-RestMethodWrapper -Uri $Uri
+    if ($null -ne $UpdateFeed) {
 
         # Grab the Windows files
-        $FileNames = $updateFeed.PSObject.Properties.name -match $res.Get.MatchFileTypes
+        $FileNames = $UpdateFeed.PSObject.Properties.name -match $res.Get.MatchFileTypes
 
-        # Grab all the version numbers
-        Try {
-            $AllVersions = [RegEx]::Matches($FileNames, $res.Get.MatchVersion) | Select-Object -ExpandProperty Value -Unique
+        try {
+            # Grab all the version numbers; Grab latest version number
+            $AllVersions = [RegEx]::Matches($FileNames, $res.Get.MatchVersion) | Select-Object -ExpandProperty "Value" -Unique
+            $Version = $AllVersions | Sort-Object { [System.Version]$_ } -Descending | Select-Object -First 1
+            Write-Verbose -Message "$($MyInvocation.MyCommand): Latest version: $Version."
         }
-        Catch {
-            Throw "$($MyInvocation.MyCommand): Failed to extract version numbers from $uri"
+        catch {
+            throw "$($MyInvocation.MyCommand): Failed to extract version numbers from $uri. $($_.Exception.Message)"
         }
-
-        # Grab latest version number
-        $Version = ($AllVersions | Sort-Object { [System.Version]$_ } -Descending) | Select-Object -First 1
-        Write-Verbose -Message "$($MyInvocation.MyCommand): Latest version: $Version."
 
         # Grab latest Windows files
-        $LatestReleases = $FileNames -match $Version
+        $LatestReleases = ($FileNames -match $Version)[-1]
 
         # We need to rebase the timestamps from unix time, so need the Unix Epoch
         $UnixEpoch = ([System.DateTime] '1970-01-01Z').ToUniversalTime()
 
         # Build the output object for each release
-        ForEach ($Release in $LatestReleases) {
+        foreach ($Release in $LatestReleases) {
+
             # Construct the output; Return the custom object to the pipeline
             $PSObject = [PSCustomObject] @{
                 Version      = $Version
-                Architecture = Get-Architecture $Release
-                Date         = $UnixEpoch.AddSeconds($updateFeed.$Release.mtime)
-                Size         = $updateFeed.$Release.size
-                MD5          = $updateFeed.$Release.md5
-                Sha256       = $updateFeed.$Release.sha256
+                Architecture = Get-Architecture -String $Release
+                Date         = $UnixEpoch.AddSeconds($UpdateFeed.$Release.mtime)
+                Size         = $UpdateFeed.$Release.size
+                MD5          = $UpdateFeed.$Release.md5
+                Sha256       = $UpdateFeed.$Release.sha256
                 URI          = $res.Get.Update.Uri -replace "#replace", $release
             }
             Write-Output -InputObject $PSObject
         }
-    }
-    Else {
-        Write-Warning -Message "$($MyInvocation.MyCommand): unable to retrieve content from $Uri."
     }
 }

--- a/Evergreen/Apps/Get-Microsoft.NET.ps1
+++ b/Evergreen/Apps/Get-Microsoft.NET.ps1
@@ -1,4 +1,4 @@
-Function Get-Microsoft.NET {
+function Get-Microsoft.NET {
     <#
         .SYNOPSIS
             Returns the available Microsoft .NET Desktop Runtime versions and download URIs.
@@ -10,18 +10,18 @@ Function Get-Microsoft.NET {
     [OutputType([System.Management.Automation.PSObject])]
     [CmdletBinding(SupportsShouldProcess = $False)]
     param (
-        [Parameter(Mandatory = $False, Position = 0)]
+        [Parameter(Mandatory = $false, Position = 0)]
         [ValidateNotNull()]
         [System.Management.Automation.PSObject]
         $res = (Get-FunctionResource -AppName ("$($MyInvocation.MyCommand)".Split("-"))[1])
     )
 
     # Read the version number from the version URI
-    ForEach ($Channel in $res.Get.Update.Channels) {
+    foreach ($Channel in $res.Get.Update.Channels) {
 
         # Determine the version for each channel
         $Content = Invoke-RestMethodWrapper -Uri $($res.Get.Update.Uri -replace $res.Get.Update.ReplaceText, $Channel)
-        If ($Null -ne $Content) {
+        if ($null -ne $Content) {
 
             # Read last line of the returned content to retrieve the version number
             Write-Verbose -Message "$($MyInvocation.MyCommand): Returned: $Content."
@@ -39,12 +39,12 @@ Function Get-Microsoft.NET {
             Write-Verbose -Message "$($MyInvocation.MyCommand): Found $($Releases.releases.Count) release/s."
 
             # Step through each release type
-            ForEach ($Installer in $res.Get.Download.Installers) {
+            foreach ($Installer in $res.Get.Download.Installers) {
                 Write-Verbose -Message "$($MyInvocation.MyCommand): Build for type: $Installer."
                 Write-Verbose -Message "$($MyInvocation.MyCommand): Found $($Releases.releases[0].$Installer.files.count) files."
 
                 # Each installer includes multiple file types and platforms
-                ForEach ($File in $Releases.releases[0].$Installer.files) {
+                foreach ($File in $Releases.releases[0].$Installer.files) {
 
                     # Filter for .exe only so that we get Windows installers
                     $File | Where-Object { $_.name -match "\.exe$" } | ForEach-Object {
@@ -52,9 +52,10 @@ Function Get-Microsoft.NET {
                         # Build the output object; Output object to the pipeline
                         $PSObject = [PSCustomObject] @{
                             Version      = $Releases.releases[0].$Installer.version
-                            Architecture = Get-Architecture -String $_.rid
+                            Architecture = if ($_.rid.length -gt 0) { Get-Architecture -String $_.rid } else { Get-Architecture -String $_.url }
                             Installer    = $Installer
                             Channel      = $Channel
+                            Hash         = $_.hash
                             Type         = [System.IO.Path]::GetExtension($_.url).Split(".")[-1]
                             URI          = $_.url
                         }

--- a/Evergreen/Apps/Get-MicrosoftAzureCLI.ps1
+++ b/Evergreen/Apps/Get-MicrosoftAzureCLI.ps1
@@ -1,0 +1,24 @@
+function Get-MicrosoftAzureCLI {
+    <#
+        .NOTES
+            Author: Aaron Parker
+            Twitter: @stealthpuppy
+    #>
+    [OutputType([System.Management.Automation.PSObject])]
+    [CmdletBinding(SupportsShouldProcess = $False)]
+    param (
+        [Parameter(Mandatory = $False, Position = 0)]
+        [ValidateNotNull()]
+        [System.Management.Automation.PSObject]
+        $res = (Get-FunctionResource -AppName ("$($MyInvocation.MyCommand)".Split("-"))[1])
+    )
+
+    # Pass the repo releases API URL and return a formatted object
+    $params = @{
+        Uri          = $res.Get.Uri
+        MatchVersion = $res.Get.MatchVersion
+        Filter       = $res.Get.MatchFileTypes
+    }
+    $object = Get-GitHubRepoRelease @params
+    Write-Output -InputObject $object
+}

--- a/Evergreen/Apps/Get-Win32OpenSSH.ps1
+++ b/Evergreen/Apps/Get-Win32OpenSSH.ps1
@@ -1,4 +1,4 @@
-Function Get-Win32OpenSSH {
+function Get-Win32OpenSSH {
     <#
         .SYNOPSIS
             Returns the available Win32-OpenSSH versions.

--- a/Evergreen/Manifests/Microsoft.NET.json
+++ b/Evergreen/Manifests/Microsoft.NET.json
@@ -1,5 +1,5 @@
 {
-    "Name": "Microsoft .NET Desktop Runtime",
+    "Name": "Microsoft .NET",
     "Source": "https://dotnet.microsoft.com/download/",
     "Get": {
         "Update": {
@@ -16,7 +16,8 @@
             "Installers": [
                 "windowsdesktop",
                 "runtime",
-                "sdk"
+                "sdk",
+                "aspnetcore-runtime"
             ]
         }
     },

--- a/Evergreen/Manifests/Microsoft.NET.json
+++ b/Evergreen/Manifests/Microsoft.NET.json
@@ -7,8 +7,7 @@
             "ReplaceText": "#channel",
             "Channels": [
                 "Current",
-                "LTS",
-                "3.1"
+                "LTS"
             ]
         },
         "Download": {

--- a/Evergreen/Manifests/MicrosoftAzureCLI.json
+++ b/Evergreen/Manifests/MicrosoftAzureCLI.json
@@ -1,0 +1,21 @@
+{
+	"Name": "Microsoft Azure CLI",
+	"Source": "https://learn.microsoft.com/en-au/cli/azure/",
+	"Get": {
+		"Uri": "https://api.github.com/repos/Azure/azure-cli/releases/latest",
+		"MatchVersion": "(\\d+(\\.\\d+){1,4}).*",
+		"MatchFileTypes": "\\.exe$|\\.msi$|\\.msp$"
+	},
+	"Install": {
+		"Setup": "",
+		"Preinstall": "",
+		"Physical": {
+			"Arguments": "",
+			"PostInstall": []
+		},
+		"Virtual": {
+			"Arguments": "",
+			"PostInstall": []
+		}
+	}
+}

--- a/Evergreen/Manifests/Win32OpenSSH.json
+++ b/Evergreen/Manifests/Win32OpenSSH.json
@@ -4,7 +4,7 @@
 	"Get": {
 		"Uri": "https://api.github.com/repos/PowerShell/Win32-OpenSSH/releases/latest",
 		"MatchVersion": "(\\d+(\\.\\d+){1,4}).*",
-		"MatchFileTypes": "^(?!.*Symbols).*zip$|.*exe$"
+		"MatchFileTypes": "^(?!.*Symbols).*zip$|\\.exe$|\\.msi$"
 	},
 	"Install": {
 		"Setup": "OpenSSH*.zip",

--- a/Evergreen/Public/Get-EvergreenLibraryApp.ps1
+++ b/Evergreen/Public/Get-EvergreenLibraryApp.ps1
@@ -36,7 +36,7 @@ function Get-EvergreenLibraryApp {
         $Application = $Inventory.Inventory | Where-Object { $_.ApplicationName -eq $Name }
         if ($null -ne $Application) {
             Write-Verbose -Message "Filtering library inventory for '$Name'"
-            Write-Output -InputObject ($Application.Versions | Sort-Object -Property @{ Expression = { [System.Version]$_.Version }; Descending = $true })
+            Write-Output -InputObject ($Application.Versions | Sort-Object -Property @{ Expression = { [System.Version]$_.Version }; Descending = $true } -ErrorAction "SilentlyContinue")
         }
         else {
             Write-Error -Message "Cannot find an application in the library that matches '$Name'"

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,8 +2,9 @@
 
 ## VERSION
 
-* Add `mySQLWorkbench` [[#499](https://github.com/aaronparker/evergreen/issues/499)
+* Add `mySQLWorkbench` [#499](https://github.com/aaronparker/evergreen/issues/499)
 * Update `Get-GitHubRepoRelease` to support finding a version number from repository tags
+* Fix an issue in `ChromiumChromeDriver` where the version doesn't match Google Chrome [#500](https://github.com/aaronparker/evergreen/issues/500)
 
 ## 2305.798
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,9 +2,14 @@
 
 ## VERSION
 
-* Add `mySQLWorkbench` [#499](https://github.com/aaronparker/evergreen/issues/499)
+* Add `mySQLWorkbench` [#499](https://github.com/aaronparker/evergreen/issues/499), `MicrosoftAzureCLI` [#506](https://github.com/aaronparker/evergreen/issues/506)
+* Adds MSI file type to `Win32OpenSSH` [#505](https://github.com/aaronparker/evergreen/issues/505)
+* Adds Windows Server Hosting and ASP Net Core Runtimes to `Microsoft.NET` [#501](https://github.com/aaronparker/evergreen/issues/501)
+* Update `Get-EvergreenLibraryApp` to account for non-standard version numbers [#502](https://github.com/aaronparker/evergreen/issues/502)
 * Update `Get-GitHubRepoRelease` to support finding a version number from repository tags
+* Fix a duplicate object issue in `Anaconda` [#503](https://github.com/aaronparker/evergreen/issues/503)
 * Fix an issue in `ChromiumChromeDriver` where the version doesn't match Google Chrome [#500](https://github.com/aaronparker/evergreen/issues/500)
+* Removes version `3.1` from `Microsoft.NET` [#507](https://github.com/aaronparker/evergreen/issues/507)
 
 ## 2305.798
 


### PR DESCRIPTION
* Add `mySQLWorkbench` [#499](https://github.com/aaronparker/evergreen/issues/499), `MicrosoftAzureCLI` [#506](https://github.com/aaronparker/evergreen/issues/506)
* Adds MSI file type to `Win32OpenSSH` [#505](https://github.com/aaronparker/evergreen/issues/505)
* Adds Windows Server Hosting and ASP Net Core Runtimes to `Microsoft.NET` [#501](https://github.com/aaronparker/evergreen/issues/501)
* Update `Get-EvergreenLibraryApp` to account for non-standard version numbers [#502](https://github.com/aaronparker/evergreen/issues/502)
* Update `Get-GitHubRepoRelease` to support finding a version number from repository tags
* Fix a duplicate object issue in `Anaconda` [#503](https://github.com/aaronparker/evergreen/issues/503)
* Fix an issue in `ChromiumChromeDriver` where the version doesn't match Google Chrome [#500](https://github.com/aaronparker/evergreen/issues/500)
* Removes version `3.1` from `Microsoft.NET` [#507](https://github.com/aaronparker/evergreen/issues/507)