### PR TITLE
Fix: OpenLens add msi, fix portable/setup type

### DIFF
--- a/Evergreen/Apps/Get-OpenLens.ps1
+++ b/Evergreen/Apps/Get-OpenLens.ps1
@@ -5,6 +5,7 @@ Function Get-OpenLens {
 
         .NOTES
             Author: Kirill Trofimov
+            Author: BornToBeRoot
     #>
     [OutputType([System.Management.Automation.PSObject])]
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseSingularNouns", "", Justification="Product name is a plural")]
@@ -23,5 +24,16 @@ Function Get-OpenLens {
         Filter       = $res.Get.MatchFileTypes
     }
     $object = Get-GitHubRepoRelease @params
+
+    # For windows there are two different .exe versions.
+    # Setup:   OpenLens.Setup.6.5.2-366.exe
+    # Portable: OpenLens.6.5.2-366.exe
+    foreach($o in $object) {
+        if(-not($o.URI.contains("Setup")) -and $o.URI.EndsWith(".exe"))
+        {
+            $o.InstallerType = "Portable"
+        }
+    }
+
     Write-Output -InputObject $object
 }

--- a/Evergreen/Apps/Get-OpenLens.ps1
+++ b/Evergreen/Apps/Get-OpenLens.ps1
@@ -26,7 +26,7 @@ Function Get-OpenLens {
     $object = Get-GitHubRepoRelease @params
 
     # For windows there are two different .exe versions.
-    # Setup:   OpenLens.Setup.6.5.2-366.exe
+    # Setup:    OpenLens.Setup.6.5.2-366.exe
     # Portable: OpenLens.6.5.2-366.exe
     foreach($o in $object) {
         if(-not($o.URI.contains("Setup")) -and $o.URI.EndsWith(".exe"))

--- a/Evergreen/Manifests/OpenLens.json
+++ b/Evergreen/Manifests/OpenLens.json
@@ -4,7 +4,7 @@
 	"Get": {
 		"Uri": "https://api.github.com/repos/MuhammedKalkan/OpenLens/releases/latest",
 		"MatchVersion": "(\\d+(\\.\\d+){1,4}).*",
-		"MatchFileTypes": "\\.exe$"
+		"MatchFileTypes": "\\.exe$|\\.msi$"
 	},
 	"Install": {
 		"Setup": "OpenLens-*.exe",


### PR DESCRIPTION
**OpenLens**

- Add MSI version
- Change installer Tte to Portable for 1 exe file:

![image](https://github.com/aaronparker/evergreen/assets/16019165/9d43f0fe-f57b-4d45-bf1e-f0c2fe12054c)
