### PR TITLE
Development

### DIFF
--- a/.github/workflows/test-development.yml
+++ b/.github/workflows/test-development.yml
@@ -11,7 +11,6 @@ on:
     paths:
       - 'Evergreen/**.ps1'
       - 'Evergreen/**.psm1'
-      - 'Evergreen/**.json'
 
 jobs:
   psscriptanalyzer:

--- a/.github/workflows/test-main.yml
+++ b/.github/workflows/test-main.yml
@@ -10,7 +10,6 @@ on:
     paths:
       - 'Evergreen/**.ps1'
       - 'Evergreen/**.psm1'
-      - 'Evergreen/**.json'
 
 jobs:
   psscriptanalyzer:

--- a/.github/workflows/update-module.yml
+++ b/.github/workflows/update-module.yml
@@ -40,7 +40,7 @@ jobs:
             # Importing the manifest to determine the version
             $Manifest = Test-ModuleManifest -Path $ManifestPath
             Write-Host "Old version is: $($Manifest.Version)"
-            [System.String]$NewVersion = New-Object -TypeName "System.Version" -ArgumentList ((Get-Date -Format "yyMM"), ($Manifest.Version.Minor + [System.Int32]$env:GITHUB_RUN_NUMBER + 1 ))
+            [System.String]$NewVersion = New-Object -TypeName "System.Version" -ArgumentList ((Get-Date -Format "yyMM"), ($Manifest.Version.Minor + [System.Int32]$env:GITHUB_RUN_NUMBER ))
             Write-Host "New version is: $NewVersion"
 
             # Update the manifest with the new version value and fix the weird string replace bug

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -84,6 +84,7 @@
         "Rfor",
         "rhel",
         "Rizonesoft",
+        "rstudio",
         "RTME",
         "Safing",
         "sarif",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -54,6 +54,7 @@
         "Linc",
         "linkid",
         "LTSC",
+        "Lync",
         "MAML",
         "masterpackager",
         "MERGETASKS",

--- a/Evergreen/Apps/Get-OracleJava21.ps1
+++ b/Evergreen/Apps/Get-OracleJava21.ps1
@@ -1,0 +1,18 @@
+﻿function Get-OracleJava21 {
+    <#
+        .NOTES
+            Author: Aaron Parker
+            Twitter: @stealthpuppy
+    #>
+    [OutputType([System.Management.Automation.PSObject])]
+    [CmdletBinding(SupportsShouldProcess = $false)]
+    param (
+        [Parameter(Mandatory = $false, Position = 0)]
+        [ValidateNotNullOrEmpty()]
+        [System.Management.Automation.PSObject]
+        $res = (Get-FunctionResource -AppName ("$($MyInvocation.MyCommand)".Split("-"))[1])
+    )
+
+    $Output = Get-OracleJava -res $res
+    Write-Output -InputObject $Output
+}

--- a/Evergreen/Apps/Get-RStudio.ps1
+++ b/Evergreen/Apps/Get-RStudio.ps1
@@ -1,4 +1,4 @@
-Function Get-RStudio {
+function Get-RStudio {
     <#
         .SYNOPSIS
             Returns the available RStudio version and download URI.
@@ -9,48 +9,31 @@ Function Get-RStudio {
             Based on Get-AtlassianBitbucket.ps1
     #>
     [OutputType([System.Management.Automation.PSObject])]
-    [CmdletBinding(SupportsShouldProcess = $False)]
+    [CmdletBinding(SupportsShouldProcess = $false)]
     param (
-        [Parameter(Mandatory = $False, Position = 0)]
+        [Parameter(Mandatory = $false, Position = 0)]
         [ValidateNotNull()]
         [System.Management.Automation.PSObject]
         $res = (Get-FunctionResource -AppName ("$($MyInvocation.MyCommand)".Split("-"))[1])
     )
 
-    # Read the update URI
-    foreach ($branch in $res.Get.Update.Uri.GetEnumerator()) {
-        $params = @{
-            Uri = $res.Get.Update.Uri[$branch.Key]
-        }
-        $Content = Invoke-RestMethodWrapper @params
+    # Read the download URI
+    $Content = Invoke-RestMethodWrapper -Uri $res.Get.Download.Uri
 
-        # Read the JSON and build an array of platform, channel, version
-        If ($Null -ne $Content) {
+    # Step through each installer type
+    foreach ($Product in $res.Get.Download.Products) {
 
-            # Step through each installer type
-            foreach ($product in $res.Get.Update.Products) {
-                foreach ($platform in $res.Get.Update.Platforms) {
-                    foreach ($item in $Content.$product.platforms.$platform) {
-
-                        # Build the output object; Output object to the pipeline
-                        $PSObject = [PSCustomObject] @{
-                            Version       = $item.version
-                            Sha256        = $item.sha256
-                            Size          = $item.size
-                            Branch        = $branch.Name
-                            Channel       = $item.channel
-                            ProductName   = $Content.$product.name
-                            InstallerName = $item.name
-                            Type          = Get-FileType -File $item.link
-                            URI           = $item.link
-                        }
-                        Write-Output -InputObject $PSObject
-                    }
-                }
-            }
+        # Build the output object; Output object to the pipeline
+        $PSObject = [PSCustomObject] @{
+            Version      = $Content.rstudio.$Product.stable.desktop.installer.windows.version
+            ProductName  = $Content.rstudio.$Product.stable.desktop.installer.windows.label
+            Pro          = $Content.rstudio.$Product.stable.desktop.installer.windows.pro
+            Date         = $Content.rstudio.$Product.stable.desktop.installer.windows.last_modified
+            Size         = $Content.rstudio.$Product.stable.desktop.installer.windows.size
+            Sha256       = $Content.rstudio.$Product.stable.desktop.installer.windows.sha256
+            Type         = Get-FileType -File $Content.rstudio.$Product.stable.desktop.installer.windows.url
+            URI          = $Content.rstudio.$Product.stable.desktop.installer.windows.url
         }
-        else {
-            Write-Error -Message "$($MyInvocation.MyCommand): Unable to return usable content from: $($res.Get.Update.Uri[$branch.Key])."
-        }
+        Write-Output -InputObject $PSObject
     }
 }

--- a/Evergreen/Apps/Get-Zoom.ps1
+++ b/Evergreen/Apps/Get-Zoom.ps1
@@ -4,8 +4,8 @@ function Get-Zoom {
             Get the current version and download URL for Zoom.
 
         .NOTES
-            Author: Trond Eirik Haavarstein
-            Twitter: @xenappblog
+            Author: Aaron Parker
+            Twitter: @stealthpuppy
     #>
     [OutputType([System.Management.Automation.PSObject])]
     [CmdletBinding(SupportsShouldProcess = $False)]
@@ -15,48 +15,6 @@ function Get-Zoom {
         [System.Management.Automation.PSObject]
         $res = (Get-FunctionResource -AppName ("$($MyInvocation.MyCommand)".Split("-"))[1])
     )
-
-    <#
-    foreach ($platform in $res.Get.Download.Keys) {
-        foreach ($installer in $res.Get.Download[$platform].Keys) {
-
-            # Follow the download link which will return a 301/302
-            $redirectUrl = Resolve-SystemNetWebRequest -Uri $res.Get.Download[$platform][$installer]
-
-            # Match the URL without the text after the ?
-            if ($null -eq $redirectUrl) {
-                Write-Verbose -Message "$($MyInvocation.MyCommand): Setting fallback URL to: $($script:resourceStrings.Uri.Issues)."
-                $Url = $script:resourceStrings.Uri.Issues
-            }
-            else {
-                try {
-                    $Url = [RegEx]::Match($redirectUrl.ResponseUri.AbsoluteUri, $res.Get.MatchUrl).Captures.Groups[1].Value
-                }
-                catch {
-                    $Url = $redirectUrl.ResponseUri.AbsoluteUri
-                }
-            }
-
-            # Match version number from the download URL
-            try {
-                $Version = [RegEx]::Match($Url, $res.Get.MatchVersion).Captures.Groups[0].Value
-            }
-            catch {
-                $Version = "Latest"
-            }
-
-            # Construct the output; Return the custom object to the pipeline
-            $PSObject = [PSCustomObject] @{
-                Version      = $Version
-                Platform     = $platform
-                Type         = Get-FileType -File $Url
-                Architecture = Get-Architecture -String $Url
-                URI          = $Url
-            }
-            Write-Output -InputObject $PSObject
-        }
-    }
-    #>
 
     # Get the download data from the API
     $params = @{
@@ -88,7 +46,7 @@ function Get-Zoom {
         }
 
         # Create an output object
-        [PSCustomObject]@{
+        $Output = [PSCustomObject]@{
             Version      = $Version
             Platform     = $res.Get.Download.PropertyMatrix[$Property]
             Installer    = "User"
@@ -97,6 +55,7 @@ function Get-Zoom {
             Architecture = Get-Architecture -String $ResolvedUrl.ResponseUri.AbsoluteUri
             URI          = $ResolvedUrl.ResponseUri.AbsoluteUri
         }
+        Write-Output -InputObject $Output
 
         # Construct the URL for the IT installer
         if (-not([System.String]::IsNullOrEmpty($DownloadFeed.result.downloadVO.$Property.packageNameForIT))) {
@@ -111,7 +70,7 @@ function Get-Zoom {
             $ResolvedUrl = Resolve-SystemNetWebRequest -Uri $Url
 
             # Create an output object
-            [PSCustomObject]@{
+            $Output = [PSCustomObject]@{
                 Version      = $Version
                 Platform     = $res.Get.Download.PropertyMatrix[$Property]
                 Installer    = "Admin"
@@ -120,6 +79,7 @@ function Get-Zoom {
                 Architecture = Get-Architecture -String $ResolvedUrl.ResponseUri.AbsoluteUri
                 URI          = $ResolvedUrl.ResponseUri.AbsoluteUri
             }
+            Write-Output -InputObject $Output
         }
     }
 }

--- a/Evergreen/Apps/Get-ZoomVDI.ps1
+++ b/Evergreen/Apps/Get-ZoomVDI.ps1
@@ -1,0 +1,46 @@
+function Get-ZoomVDI {
+    <#
+        .SYNOPSIS
+            Get the current version and download URL for Zoom VDI
+
+        .NOTES
+            Author: Aaron Parker
+            Twitter: @stealthpuppy
+    #>
+    [OutputType([System.Management.Automation.PSObject])]
+    [CmdletBinding(SupportsShouldProcess = $False)]
+    param (
+        [Parameter(Mandatory = $False, Position = 0)]
+        [ValidateNotNull()]
+        [System.Management.Automation.PSObject]
+        $res = (Get-FunctionResource -AppName ("$($MyInvocation.MyCommand)".Split("-"))[1])
+    )
+
+    # Step through each URL
+    foreach ($Url in $res.Get.Download.Uri) {
+
+        # Resolve the download URL
+        $ResolvedUrl = Resolve-SystemNetWebRequest -Uri $Url
+        $Uri = ($ResolvedUrl.ResponseUri.AbsoluteUri -split "\?")[0]
+
+        # Create the platform from the file name in the URL
+        switch -Regex ($ResolvedUrl.ResponseUri.AbsoluteUri) {
+            "Installer" { $Platform = "VDIClient"; break }
+            "Citrix" { $Platform = "Citrix"; break }
+            "Universal" { $Platform = "Universal"; break }
+            default { $Platform = "VDI" }
+        }
+
+        # Create an output object
+        $Output = [PSCustomObject]@{
+            Version      = "Latest"
+            Platform     = $Platform
+            Installer    = "Admin"
+            Size         = $ResolvedUrl.ContentLength
+            Type         = Get-FileType -File $Uri
+            Architecture = Get-Architecture -String $Uri
+            URI          = $Uri
+        }
+        Write-Output -InputObject $Output
+    }
+}

--- a/Evergreen/Manifests/AdoptiumTemurin19.json
+++ b/Evergreen/Manifests/AdoptiumTemurin19.json
@@ -1,5 +1,5 @@
 {
-    "Name": "Adoptium Temurin 18",
+    "Name": "Adoptium Temurin 19",
     "Source": "https://adoptium.net/",
     "Get": {
         "Update": {

--- a/Evergreen/Manifests/AdoptiumTemurin20.json
+++ b/Evergreen/Manifests/AdoptiumTemurin20.json
@@ -1,5 +1,5 @@
 {
-    "Name": "Adoptium Temurin 18",
+    "Name": "Adoptium Temurin 20",
     "Source": "https://adoptium.net/",
     "Get": {
         "Update": {

--- a/Evergreen/Manifests/OracleJava20.json
+++ b/Evergreen/Manifests/OracleJava20.json
@@ -1,6 +1,6 @@
 {
     "Name": "Oracle Java 20",
-    "Source": "https://www.java.com",
+    "Source": "https://www.oracle.com/java/technologies/downloads/#java20",
     "Get": {
         "Update": {
             "Uri": "https://www.java.com/releases/releases.json",

--- a/Evergreen/Manifests/OracleJava21.json
+++ b/Evergreen/Manifests/OracleJava21.json
@@ -1,6 +1,6 @@
 {
-    "Name": "Oracle Java 17",
-    "Source": "https://www.oracle.com/java/technologies/downloads/#java17",
+    "Name": "Oracle Java 21",
+    "Source": "https://www.oracle.com/java/technologies/downloads/#java21",
     "Get": {
         "Update": {
             "Uri": "https://www.java.com/releases/releases.json",
@@ -15,14 +15,14 @@
                 "authority": "www.java.com"
             },
             "UserAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/116.0.0.0 Safari/537.36 Edg/116.0.1938.81",
-            "Family": 17,
+            "Family": 21,
             "DateFormat": "yyyy-MM-dd"
         },
         "Download": {
             "Uri": {
-                "zip": "https://download.oracle.com/java/17/latest/jdk-17_windows-x64_bin.zip",
-                "exe": "https://download.oracle.com/java/17/latest/jdk-17_windows-x64_bin.exe",
-                "msi": "https://download.oracle.com/java/17/latest/jdk-17_windows-x64_bin.msi"
+                "zip": "https://download.oracle.com/java/21/latest/jdk-21_windows-x64_bin.zip",
+                "exe": "https://download.oracle.com/java/21/latest/jdk-21_windows-x64_bin.exe",
+                "msi": "https://download.oracle.com/java/21/latest/jdk-21_windows-x64_bin.msi"
             }
         }
     },

--- a/Evergreen/Manifests/RStudio.json
+++ b/Evergreen/Manifests/RStudio.json
@@ -1,21 +1,12 @@
 {
 	"Name": "RStudio Desktop",
-	"Source": "https://www.rstudio.com/",
+	"Source": "https://posit.co/products/open-source/rstudio/",
 	"Get": {
-		"Update": {
-            "Uri": {
-				"Spotted Wakerobin": "https://dailies.rstudio.com/rstudio/prairie-trillium/index.json",
-				"Prairie Trillium": "https://dailies.rstudio.com/rstudio/prairie-trillium/index.json",
-				"Ghost Orchid": "https://dailies.rstudio.com/rstudio/prairie-trillium/index.json",
-				"Juliet Rose": "https://dailies.rstudio.com/rstudio/juliet-rose/index.json"
-			},
+		"Download": {
+            "Uri": "https://www.rstudio.com/wp-content/downloads.json",
 			"Products": [
-				"desktop",
-				"desktop-pro"
-			],
-			"Platforms": [
-				"windows",
-				"windows-xcopy"
+				"open_source",
+				"pro"
 			]
 		}
 	},

--- a/Evergreen/Manifests/Zoom.json
+++ b/Evergreen/Manifests/Zoom.json
@@ -1,53 +1,35 @@
 {
     "Name": "Zoom",
-    "Source": "https://zoom.us/",
+    "Source": "https://zoom.us/download",
     "Get": {
         "Download": {
-            "Meetings": {
-                "Exex86": "https://zoom.us/client/latest/ZoomInstallerFull.exe",
-                "Exex64": "https://zoom.us/client/latest/ZoomInstallerFull.exe?archType=x64",
-                "ExeArm64": "https://zoom.us/client/latest/ZoomInstallerFull.exe?archType=winarm64",
-                "Msix86": "https://zoom.us/client/latest/ZoomInstallerFull.msi",
-                "Msix64": "https://zoom.us/client/latest/ZoomInstallerFull.msi?archType=x64",
-                "MsiArm64": "https://zoom.us/client/latest/ZoomInstallerFull.msi?archType=winarm64"
+            "Uri": "https://zoom.us/rest/download?os=win",
+            "ContentType": "application/json",
+            "Properties": [
+                "lyncPlugin",
+                "notesPlugin",
+                "outlookPlugin",
+                "zoom",
+                "zoomArm64",
+                "zoomRooms",
+                "zoomRoomsX64",
+                "zoomX64"
+            ],
+            "PropertyMatrix": {
+                "lyncPlugin": "Lync",
+                "notesPlugin": "Notes",
+                "outlookPlugin": "Outlook",
+                "zoom": "Desktop",
+                "zoomArm64": "Desktop",
+                "zoomRooms": "Rooms",
+                "zoomRoomsX64": "Rooms",
+                "zoomX64": "Desktop"
             },
-            "Rooms": {
-                "Exex86": "https://zoom.us/client/latest/ZoomRooms.exe",
-                "Exex64": "https://zoom.us/client/latest/ZoomRooms.exe?archType=x64",
-                "Msix86": "https://zoom.us/client/latest/ZoomRoomsInstaller.msi",
-                "Msix64": "https://zoom.us/client/latest/ZoomRoomsInstaller.msi?archType=x64"
-            },
-            "Outlook": {
-                "Msix86": "https://zoom.us/client/latest/ZoomOutlookPluginSetup.msi"
-            },
-            "Lync": {
-                "Msix86": "https://zoom.us/client/latest/ZoomLyncPluginSetup.msi"
-            },
-            "Notes": {
-                "Notes": "https://zoom.us/client/latest/ZoomNotesPluginSetup.msi",
-                "Admin": "https://zoom.us/client/latest/ZoomNotesPluginAdminTool.msi"
-            },
-            "VDI": {
-                "Host": "https://zoom.us/download/vdi/ZoomInstallerVDI.msi"
-            },
-            "Plugin": {
-                "Universal": "https://zoom.us/download/vdi/ZoomVDIUniversalPlugin.msi"
-            },
-            "AVD" : {
-                "Client": "https://zoom.us/download/vdi/ZoomWVDMediaPlugin.msi"
-            },
-            "Citrix": {
-                "Client": "https://zoom.us/download/vdi/ZoomCitrixHDXMediaPlugin.msi"
-            },
-            "VMware": {
-                "Client": "https://zoom.us/download/vdi/ZoomVmwareMediaPlugin.msi"
-            }
-        },
-        "MatchVersion": "(\\d+(\\.\\d+){1,4})",
-        "MatchUrl": "(.*)\\?"
+            "Hostname": "https://zoom.us/client"
+        }
     },
     "Install": {
-        "Setup": "Zoom*.exe",
+        "Setup": "",
         "Physical": {
             "Arguments": "",
             "PostInstall": []

--- a/Evergreen/Manifests/ZoomVDI.json
+++ b/Evergreen/Manifests/ZoomVDI.json
@@ -1,0 +1,26 @@
+{
+    "Name": "Zoom Plugins for VDI",
+    "Source": "https://support.zoom.us/hc/en-us/articles/4415057249549-VDI-releases-and-downloads",
+    "Get": {
+        "Download": {
+            "Uri": [
+                "https://zoom.us/download/vdi/ZoomInstallerVDI.msi",
+                "https://zoom.us/download/vdi/ZoomInstallerVDI.msi?archType=x64",
+                "https://zoom.us/download/vdi/ZoomCitrixHDXMediaPlugin.msi",
+                "https://zoom.us/download/vdi/ZoomVDIUniversalPlugin.msi",
+                "https://zoom.us/download/vdi/ZoomVDIUniversalPluginx64.msi?archType=x64"
+            ]
+        }
+    },
+    "Install": {
+        "Setup": "",
+        "Physical": {
+            "Arguments": "",
+            "PostInstall": []
+        },
+        "Virtual": {
+            "Arguments": "",
+            "PostInstall": []
+        }
+    }
+}

--- a/Evergreen/Private/Get-Architecture.ps1
+++ b/Evergreen/Private/Get-Architecture.ps1
@@ -21,7 +21,7 @@ function Get-Architecture {
         "win-x86"   { $architecture = "x86"; break }
         "x86_64"    { $architecture = "x64"; break }
         "x64"       { $architecture = "x64"; break }
-        "64"        { $architecture = "x64"; break }
+        #"64"        { $architecture = "x64"; break }
         "w64"       { $architecture = "x64"; break }
         "-64"       { $architecture = "x64"; break }
         "64-bit"    { $architecture = "x64"; break }

--- a/Evergreen/Private/Get-Architecture.ps1
+++ b/Evergreen/Private/Get-Architecture.ps1
@@ -21,7 +21,6 @@ function Get-Architecture {
         "win-x86"   { $architecture = "x86"; break }
         "x86_64"    { $architecture = "x64"; break }
         "x64"       { $architecture = "x64"; break }
-        #"64"        { $architecture = "x64"; break }
         "w64"       { $architecture = "x64"; break }
         "-64"       { $architecture = "x64"; break }
         "64-bit"    { $architecture = "x64"; break }
@@ -33,6 +32,7 @@ function Get-Architecture {
         "-32"       { $architecture = "x86"; break }
         "-x86"      { $architecture = "x86"; break }
         "x86"       { $architecture = "x86"; break }
+        "e64\."       { $architecture = "x64"; break }
         default {
             Write-Verbose -Message "$($MyInvocation.MyCommand): Architecture not found in $String, defaulting to x86."
             $architecture = "x86"

--- a/Evergreen/Shared/Get-OracleJava.ps1
+++ b/Evergreen/Shared/Get-OracleJava.ps1
@@ -25,7 +25,7 @@ function Get-OracleJava {
 
     # Sort the data for the latest version
     $LatestVersion = $UpdateFeed.data.releases | `
-        Where-Object { $_.family -eq $res.Get.Update.Family } | `
+        Where-Object { $_.family -eq $res.Get.Update.Family -and $_.status -eq "delivered" } | `
         Sort-Object -Property @{ Expression = { [System.Version]$_.version }; Descending = $true } -ErrorAction "SilentlyContinue" | `
         Select-Object -First 1
     Write-Verbose -Message "$($MyInvocation.MyCommand): Found version: $($LatestVersion.version)"

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,16 @@
 # Change log
 
+## VERSION
+
+* Adds `OracleJava21`, `ZoomVDI`
+* Updates `RStudio` to use the Stable release feed instead of the Dailies feed [#554](https://github.com/aaronparker/evergreen/issues/554)
+* Updates `Zoom` to use the download JSON found in the Zoom downloads page [#555](https://github.com/aaronparker/evergreen/issues/555)
+* Fixes an issue with `OracleJava17` (and all Oracle Java apps) where a later version was returned instead of the release version [#558](https://github.com/aaronparker/evergreen/issues/558)
+
+BREAKING CHANGES
+
+* `Zoom` has been split into `Zoom` and `ZoomVDI`. These functions also provide different property values. [#556](https://github.com/aaronparker/evergreen/discussions/556)
+
 ## 2309.859
 
 * Adds `OracleJava20`, `OracleJava17` [#381](https://github.com/aaronparker/evergreen/issues/381)


### PR DESCRIPTION
* Adds `OracleJava21`, `ZoomVDI`
* Updates `RStudio` to use the Stable release feed instead of the Dailies feed [#554](https://github.com/aaronparker/evergreen/issues/554)
* Updates `Zoom` to use the download JSON found in the Zoom downloads page [#555](https://github.com/aaronparker/evergreen/issues/555)
* Fixes an issue with `OracleJava17` (and all Oracle Java apps) where a later version was returned instead of the release version [#558](https://github.com/aaronparker/evergreen/issues/558)

BREAKING CHANGES

* `Zoom` has been split into `Zoom` and `ZoomVDI`. These functions also provide different property values. [#556](https://github.com/aaronparker/evergreen/discussions/556)