### PR TITLE
EvergreenLibraryUpdate Fixes #488

### DIFF
--- a/Evergreen/Public/Export-EvergreenApp.ps1
+++ b/Evergreen/Public/Export-EvergreenApp.ps1
@@ -34,6 +34,13 @@ function Export-EvergreenApp {
             $InputObject += $Content
         }
 
+        foreach ($AppLibInfo in $InputObject) {
+            if (([System.Uri]$AppLibInfo.URI).Host -like '*.dl.sourceforge.net') {
+                Write-Verbose "Normalise Sourceforge download mirror URL"
+                $AppLibInfo.URI = $AppLibInfo.URI -replace ([System.Uri]$AppLibInfo.URI).Host,"nchc.dl.sourceforge.net"
+            }
+        }
+
         # Sort the content and keep unique versions
         $Properties = $InputObject | Get-Member | `
             Where-Object { $_.MemberType -eq "NoteProperty" } | Select-Object -ExpandProperty "Name" -Unique | `

--- a/Evergreen/Public/Invoke-EvergreenLibraryUpdate.ps1
+++ b/Evergreen/Public/Invoke-EvergreenLibraryUpdate.ps1
@@ -55,6 +55,7 @@ function Invoke-EvergreenLibraryUpdate {
                     }
 
                     # Gather the application version information from Get-EvergreenApp
+                    [array]$App = @()
                     $App = Get-EvergreenApp -Name $Application.EvergreenApp @params | Where-Object $WhereBlock
 
                     # If something returned, add to the library
@@ -69,7 +70,7 @@ function Invoke-EvergreenLibraryUpdate {
                         # Add the saved installer path to the application version information
                         if ($Saved.Count -gt 1) {
                             for ($i = 0; $i -lt $App.Count; $i++) {
-                                $Item = $Saved | Where-Object { $_.FullName -match $App[$i].Version }
+                                $Item = $Saved | Where-Object { $_.FullName -match $App[$i].Version -and ((Split-Path $_.FullName -Leaf) -eq (Split-Path $App[$i].URI -Leaf)) }
                                 Write-Verbose -Message "Add path to object: $($Item.FullName)"
                                 $App[$i] | Add-Member -MemberType "NoteProperty" -Name "Path" -Value $Item.FullName
                             }


### PR DESCRIPTION
Code fixes for 'Evergreen Library Update' (related to comments made in issue #488) which currently result in the following issues in the Library application json files: 

1. Multiple Path entries (downloaded file references) related to a single URI
2. Non-unique entries when downloading Sourceforge based apps due to the mirror URL's changing each time.

Please see attached example json file which highlights the above issues when Invoke-EvergreenLibraryUpdate is run twice with the following EvergreenLibrary.json contents:


```json
{
    "Name":  "EvergreenLibrary",
    "Applications":  [
                         {
                             "Name":  "7Zip",
                             "EvergreenApp":  "7Zip",
                             "Filter":  "$_.Architecture -eq \"x86\""
                         }
                     ]
}
```

[7Zip.json](https://github.com/aaronparker/evergreen/files/12862130/7Zip.json)

With these code fixes applied, the resultant json file is corrected:
[7Zip.json](https://github.com/aaronparker/evergreen/files/12862136/7Zip.json)

Also added a small fix in Invoke-EvergreenLibraryUpdate.ps1 to initialise the $App variable as an array so that verbose output shows the correct number of downloads (1) when there is only 1 download, instead of blank.