### PR TITLE
Fix update uri for MicrosoftSSMS

### DIFF
--- a/.github/ISSUE_TEMPLATE/new-app.yml
+++ b/.github/ISSUE_TEMPLATE/new-app.yml
@@ -12,29 +12,21 @@ body:
     attributes:
       label: "What is the new application?"
       description: "Provide clear details about the new application you want to see added to Evergreen."
-      placeholder: "Provide details of the new application that could be added to Evergreen. Please add details of an update source/API, evergreen download links etc., where current versions of this application can be queried."
+      placeholder: "Provide details of the new application that could be added to Evergreen. Please add details of an update source/API (e.g. a JSON or XML source), evergreen download links etc., where current versions of this application can be queried."
     validations:
       required: true
   - type: input
     id: site
     attributes:
       label: "Vendor site"
-      description: "Add a link to the official site for this application"
+      description: "Add a link to the official site for this application (this can be the links that lists downloads)."
       placeholder: https://www.vendor.com
     validations:
       required: true
-  - type: checkboxes
-    id: documentation
-    attributes:
-      label: "Have you reviewed the list of supported applications?"
-      description: "Please confirm that you've reviewed the list of currently supported before making this application request." 
-      options:
-        - label: "Supported apps at: https://stealthpuppy.com/evergreen/apps/"
-          required: true
   - type: dropdown
     attributes:
       label: "Does the vendor require a sign-in to download the app?"
-      description: "If the vendor requires a sign-in to download installers, this application probably won't be a good candidate for Evergreen."
+      description: "If the vendor requires a sign-in to download installers, this application won't be a good candidate for Evergreen."
       multiple: false
       options:
         - "Yes"
@@ -51,3 +43,11 @@ body:
         - "No"
     validations:
       required: true
+  - type: checkboxes
+    id: documentation
+    attributes:
+      label: "Have you reviewed the list of supported applications?"
+      description: "Please confirm that you've reviewed the list of currently supported before making this application request." 
+      options:
+        - label: "Supported apps at: https://stealthpuppy.com/evergreen/apps/"
+          required: true

--- a/.github/ISSUE_TEMPLATE/new-app.yml
+++ b/.github/ISSUE_TEMPLATE/new-app.yml
@@ -12,7 +12,7 @@ body:
     attributes:
       label: "What is the new application?"
       description: "Provide clear details about the new application you want to see added to Evergreen."
-      placeholder: "Provide details of the new application that could be added to Evergreen. If known, please add details of an update source/API etc., where current versions of this application can be queried."
+      placeholder: "Provide details of the new application that could be added to Evergreen. Please add details of an update source/API, evergreen download links etc., where current versions of this application can be queried."
     validations:
       required: true
   - type: input
@@ -33,8 +33,18 @@ body:
           required: true
   - type: dropdown
     attributes:
-      label: "Does the vendor require a sign-in?"
+      label: "Does the vendor require a sign-in to download the app?"
       description: "If the vendor requires a sign-in to download installers, this application probably won't be a good candidate for Evergreen."
+      multiple: false
+      options:
+        - "Yes"
+        - "No"
+    validations:
+      required: true
+  - type: dropdown
+    attributes:
+      label: "Does the application include an updater?"
+      description: "Applications that actively check for updates and notify the user or automatically install updates? (These applications may be good candidates for Evergreen)"
       multiple: false
       options:
         - "Yes"

--- a/.github/workflows/publish-module.yml
+++ b/.github/workflows/publish-module.yml
@@ -15,7 +15,7 @@ jobs:
 
       - name: Install and cache PowerShell modules
         id: psmodulecache
-        uses: potatoqualitee/psmodulecache@v5.2
+        uses: potatoqualitee/psmodulecache@v6.0
         with:
           modules-to-cache: PowerShellGet
           shell: pwsh

--- a/.github/workflows/update-module.yml
+++ b/.github/workflows/update-module.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Install and cache PowerShell modules
         id: psmodulecache
-        uses: potatoqualitee/psmodulecache@v5.2
+        uses: potatoqualitee/psmodulecache@v6.0
         with:
           modules-to-cache: MarkdownPS
           shell: powershell

--- a/.github/workflows/update-module.yml
+++ b/.github/workflows/update-module.yml
@@ -101,7 +101,7 @@ jobs:
 
       - name: Commit changes
         id: commit
-        uses: stefanzweifel/git-auto-commit-action@v4
+        uses: stefanzweifel/git-auto-commit-action@v5
         with:
           commit_message: "Update module ${{steps.update-version.outputs.newversion}}"
           commit_user_name: ${{ secrets.COMMIT_NAME }}

--- a/Evergreen/Apps/Get-MicrosoftSsms.ps1
+++ b/Evergreen/Apps/Get-MicrosoftSsms.ps1
@@ -28,7 +28,6 @@ Function Get-MicrosoftSsms {
 
     If ($Null -ne $Content) {
         ForEach ($entry in $Content.component) {
-            Write-Warning -Message "$($MyInvocation.MyCommand): Version returned from the update feed: $($entry.version). See $($script:resourceStrings.Uri.Issues) for more information."
 
             ForEach ($language in $res.Get.Download.Language.GetEnumerator()) {
 

--- a/Evergreen/Manifests/MicrosoftSsms.json
+++ b/Evergreen/Manifests/MicrosoftSsms.json
@@ -3,7 +3,7 @@
 	"Source": "https://go.microsoft.com/fwlink/?LinkId=531355",
 	"Get": {
 		"Update": {
-			"Uri": "https://go.microsoft.com/fwlink/?linkid=2188980",
+			"Uri": "https://go.microsoft.com/fwlink/?linkid=2251965",
 			"DatePattern": "yyyy-MM-ddTHH:mm:ss"
 		},
 		"Download": {


### PR DESCRIPTION
Retrieved update link by installing SSMS version 19.0 manually, then used fiddler's proxy to obtain the URL that is used during the in-app update check. 

- Updated link in MicrosoftSsms.json
- Removed warning message from the Get-MicrosoftSsms.ps1 script.

Before:
![image](https://github.com/aaronparker/evergreen/assets/105817987/fc2526e8-612d-41ca-8c0d-16674f1434d1)

After:
![image](https://github.com/aaronparker/evergreen/assets/105817987/9ac43454-6a89-47f5-b8a3-aebb14bc82ab)

Note: Since Windows doesnt care about the SSLKEYLOGFILE environment variable, the proxy method was the only way that worked for me. 