### PR TITLE
Fix for RStudio

### DIFF
--- a/Evergreen/Manifests/RStudio.json
+++ b/Evergreen/Manifests/RStudio.json
@@ -2,12 +2,18 @@
 	"Name": "RStudio Desktop",
 	"Source": "https://posit.co/products/open-source/rstudio/",
 	"Get": {
+		"Update": {
+			"Uri": "https://www.rstudio.org/links/check_for_update?version=2023.12.0&os=win&format=kvp"
+		},
 		"Download": {
-            "Uri": "https://www.rstudio.com/wp-content/downloads.json",
-			"Products": [
-				"open_source",
-				"pro"
-			]
+			"Edition": [
+				"Open Source",
+				"Pro"
+			],
+			"Uri": {
+				"Open Source": "https://download1.rstudio.org/electron/windows/RStudio-",
+				"Pro": "https://download1.rstudio.org/electron/windows/RStudio-pro-"
+			}
 		}
 	},
 	"Install": {


### PR DESCRIPTION
This is a poposal for an update of the RStudio files in order to solve the issue described in issue #605 .

New output:
```
Version     : 2023.12.0-369
ProductName : RStudio Desktop
Edition     : Pro
Type        : exe
URI         : https://download1.rstudio.org/electron/windows/RStudio-pro-2023.12.0-369.pro3.exe

Version     : 2023.12.0-369
ProductName : RStudio Desktop
Edition     : Open Source
Type        : exe
URI         : https://download1.rstudio.org/electron/windows/RStudio-2023.12.0-369.exe
```
