### PR TITLE
Add Podman Desktop

### DIFF
--- a/Evergreen/Apps/Get-PodmanDesktop.ps1
+++ b/Evergreen/Apps/Get-PodmanDesktop.ps1
@@ -1,0 +1,34 @@
+Function Get-PodmanDesktop {
+    <#
+        .SYNOPSIS
+            Returns the available Podman Desktop versions.
+
+        .NOTES
+            Author: Kirill Trofimov
+    #>
+    [OutputType([System.Management.Automation.PSObject])]
+    [CmdletBinding(SupportsShouldProcess = $False)]
+    param (
+        [Parameter(Mandatory = $False, Position = 0)]
+        [ValidateNotNull()]
+        [System.Management.Automation.PSObject]
+        $res = (Get-FunctionResource -AppName ("$($MyInvocation.MyCommand)".Split("-"))[1])
+    )
+
+    # Pass the repo releases API URL and return a formatted object
+    $params = @{
+        Uri          = $res.Get.Uri
+        MatchVersion = $res.Get.MatchVersion
+        Filter       = $res.Get.MatchFileTypes
+    }
+    $object = Get-GitHubRepoRelease @params
+
+    # For windows there are two different .exe versions.
+    foreach ($o in $object) {
+        if (-not($o.URI.contains("setup")) -and $o.URI.EndsWith(".exe")) {
+            $o.InstallerType = "Portable"
+        }
+    }
+
+    Write-Output -InputObject $object
+}

--- a/Evergreen/Manifests/PodmanDesktop.json
+++ b/Evergreen/Manifests/PodmanDesktop.json
@@ -1,0 +1,20 @@
+{
+	"Name": "Podman Desktop",
+	"Source": "https://github.com/containers/podman-desktop",
+	"Get": {
+		"Uri": "https://api.github.com/repos/containers/podman-desktop/releases/latest",
+		"MatchVersion": "(\\d+(\\.\\d+){1,4}).*",
+		"MatchFileTypes": "\\.exe$"
+	},
+	"Install": {
+		"Setup": "podman-desktop*.exe",
+		"Physical": {
+			"Arguments": "/S",
+			"PostInstall": []
+		},
+		"Virtual": {
+			"Arguments": "",
+			"PostInstall": []
+		}
+	}
+}

--- a/Evergreen/Private/Get-InstallerType.ps1
+++ b/Evergreen/Private/Get-InstallerType.ps1
@@ -12,6 +12,7 @@ function Get-InstallerType {
         "portable"     { $Type = "Portable"; break }
         "no-installer" { $Type = "Portable"; break }
         "debug"        { $Type = "Debug"; break }
+        "airgap"       { $Type = "Airgap"; break }
         default {
             Write-Verbose -Message "$($MyInvocation.MyCommand): Installer type not found in $String, defaulting to 'Default'."
             $Type = "Default"

--- a/tests/Private/Get-InstallerType.Tests.ps1
+++ b/tests/Private/Get-InstallerType.Tests.ps1
@@ -41,5 +41,13 @@ Describe -Name "Get-InstallerType" {
                 Get-InstallerType -String $Url | Should -Be "Debug"
             }
         }
+
+        It "Returns Airgap given an airgap URL" {
+            InModuleScope -ModuleName "Evergreen" {
+                $Url = "https://github.com/containers/podman-desktop/releases/download/v1.6.4/podman-desktop-airgap-1.6.4-x64.exe"
+                Get-InstallerType -String $Url | Should -Be "Airgap"
+            }
+        }
+
     }
 }


### PR DESCRIPTION
Hello,

Adding new app: https://github.com/containers/podman-desktop

One thing, maintainer providing "airgap" version for the app, as for "portable" version and for "setup" version.
Do we need to think about it? I prepared MR with added "Airgap" type, but it's tricky, so before implementing it - I would like to hear your thoughts about it.

Best