### PR TITLE
Fix: Remove "v" from Kubernetes Kubectl version

### DIFF
--- a/Evergreen/Apps/Get-KubernetesKubectl.ps1
+++ b/Evergreen/Apps/Get-KubernetesKubectl.ps1
@@ -22,7 +22,7 @@ function Get-KubernetesKubectl {
     # Build the download links for each platform & architecture
     foreach ($DownloadUri in $res.Get.Download.Uri.GetEnumerator()) {
         [PSCustomObject] @{
-            Version      = $Version
+            Version      = $Version.TrimStart("v")
             Architecture = $DownloadUri.Name.Split("_")[1]
             Platform     = $DownloadUri.Name.Split("_")[0]
             URI          = $DownloadUri.Value -replace $res.Get.Download.ReplaceVersionText, $Version

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -11,7 +11,7 @@ repo_url: https://github.com/aaronparker/evergreen
 edit_uri: ""
 
 # Copyright
-copyright: Copyright &copy; 2023 Aaron Parker
+copyright: Copyright &copy; 2024 Aaron Parker
 
 # Configuration
 theme:


### PR DESCRIPTION
v1.29.3 -> 1.29.3