### PR TITLE
Add Argument Completer

### DIFF
--- a/Evergreen/Evergreen.psm1
+++ b/Evergreen/Evergreen.psm1
@@ -29,3 +29,8 @@ Export-ModuleMember -Function $public.Basename -Alias *
 
 # Get module strings
 $script:resourceStrings = Get-ModuleResource
+
+Register-ArgumentCompleter -CommandName 'Get-EvergreenApp', 'Find-EvergreenApp' -ParameterName 'Name' -ScriptBlock {
+    param($commandName, $parameterName, $wordToComplete, $commandAst, $fakeBoundParameters)
+    (Get-ChildItem -Path "$PSScriptRoot\Manifests\$wordToComplete*.json" -ErrorAction Ignore).BaseName
+}


### PR DESCRIPTION
This adds an argument completer to Get-EvergreenApp and Find-EvergreenApp.

I found having to run find repeatedly followed by get tiresome, so now for most apps you can just enter the first few letters of the app name and hit tab to auto complete!

Shoutout to @codaamok who added something similar to Nevergreen.