### PR TITLE
Development

### DIFF
--- a/Evergreen/Evergreen.json
+++ b/Evergreen/Evergreen.json
@@ -3,14 +3,14 @@
         "ErrorAction": "Stop"
     },
     "UserAgent": {
-		"Base": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36",
+		"Base": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36 Edg/124.0.2478.67",
         "Download": [
-            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36",
+            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36 Edg/124.0.2478.67",
             "Googlebot/2.1 (+http://www.google.com/bot.html)"
         ]
     },
     "Filters": {
-        "WindowsInstallers": "\\.exe$|\\.msi$|\\.msp$|\\.zip$|\\.msix$||\\.msixbundle$\\.appx$",
+        "WindowsInstallers": "\\.exe$|\\.msi$|\\.msp$|\\.zip$|\\.msix$|\\.msixbundle$|\\.appx$|\\.intunewin$",
         "Filename": "(([a-zA-Z0-9\\s_\\.\\-\\(\\):])+(.exe|.msi|.msp|.zip|.msix|.msixbundle|.appx))"
     },
     "Properties": {

--- a/Evergreen/Evergreen.json
+++ b/Evergreen/Evergreen.json
@@ -3,9 +3,9 @@
         "ErrorAction": "Stop"
     },
     "UserAgent": {
-		"Base": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36 Edg/122.0.0.",
+		"Base": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36",
         "Download": [
-            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36 Edg/122.0.0.",
+            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36",
             "Googlebot/2.1 (+http://www.google.com/bot.html)"
         ]
     },

--- a/Evergreen/Evergreen.json
+++ b/Evergreen/Evergreen.json
@@ -10,8 +10,8 @@
         ]
     },
     "Filters": {
-        "WindowsInstallers": "\\.exe$|\\.msi$|\\.msp$|\\.zip$",
-        "Filename": "(([a-zA-Z0-9\\s_\\.\\-\\(\\):])+(.exe|.msi|.msp|.zip))"
+        "WindowsInstallers": "\\.exe$|\\.msi$|\\.msp$|\\.zip$|\\.msix$||\\.msixbundle$\\.appx$",
+        "Filename": "(([a-zA-Z0-9\\s_\\.\\-\\(\\):])+(.exe|.msi|.msp|.zip|.msix|.msixbundle|.appx))"
     },
     "Properties": {
         "SourceForge": [

--- a/Evergreen/Evergreen.psd1
+++ b/Evergreen/Evergreen.psd1
@@ -82,7 +82,7 @@ CmdletsToExport = @()
 # VariablesToExport = @()
 
 # Aliases to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no aliases to export.
-AliasesToExport = 'sea', 'gea', 'fea', 'tea', 'iea'
+AliasesToExport = 'sea', 'gea', 'fea', 'tea', 'iea', 'Get-EvergreenAppFromApi', 'Start-EvergreenLibraryUpdate'
 
 # DSC resources to export from this module
 # DscResourcesToExport = @()

--- a/Evergreen/EvergreenLibraryTemplate.json
+++ b/Evergreen/EvergreenLibraryTemplate.json
@@ -9,12 +9,17 @@
         {
             "Name": "MicrosoftOneDrive",
             "EvergreenApp": "MicrosoftOneDrive",
-            "Filter": "$_.Architecture -eq \"AMD64\" -and $_.Ring -eq \"Production\""
+            "Filter": "$_.Architecture -eq \"AMD64\" -and $_.Ring -eq \"Production\" -and $_.Throttle -eq \"10\""
         },
         {
             "Name": "MicrosoftEdge",
             "EvergreenApp": "MicrosoftEdge",
-            "Filter": "$_.Platform -eq \"Windows\" -and $_.Channel -eq \"Stable\" -and $_.Release -eq \"Enterprise\" -and $_.Architecture -eq \"x64\""
+            "Filter": "$_.Channel -eq \"Stable\" -and $_.Architecture -eq \"x64\" -and $_.Release -eq \"Enterprise\""
+        },
+        {
+            "Name": "MicrosoftEdgeWebView2Runtime",
+            "EvergreenApp": "MicrosoftEdgeWebView2Runtime",
+            "Filter": "$_.Channel -eq \"Stable\" -and $_.Architecture -eq \"x64\""
         },
         {
             "Name": "MicrosoftTeams",

--- a/Evergreen/EvergreenLibraryTemplate.json
+++ b/Evergreen/EvergreenLibraryTemplate.json
@@ -19,7 +19,7 @@
         {
             "Name": "MicrosoftTeams",
             "EvergreenApp": "MicrosoftTeams",
-            "Filter": "$_.Ring -eq \"General\" -and $_.Architecture -eq \"x64\" -and $_.Type -eq \"msi\""
+            "Filter": "$_.Architecture -eq \"x64\" -and $_.Release -eq \"Enterprise\""
         }
     ]
 }

--- a/Evergreen/Private/Get-Architecture.ps1
+++ b/Evergreen/Private/Get-Architecture.ps1
@@ -8,7 +8,7 @@ function Get-Architecture {
 
     switch -Regex ($String.ToLower()) {
         "aarch64"   { $architecture = "ARM64"; break }
-        "amd64"     { $architecture = "AMD64"; break }
+        "amd64"     { $architecture = "x64"; break }
         "arm64"     { $architecture = "ARM64"; break }
         "arm32"     { $architecture = "ARM32"; break }
         "arm"       { $architecture = "ARM32"; break }

--- a/Evergreen/Private/Invoke-SystemNetRequest.ps1
+++ b/Evergreen/Private/Invoke-SystemNetRequest.ps1
@@ -10,6 +10,10 @@ Function Invoke-SystemNetRequest {
         [ValidateNotNullOrEmpty()]
         [System.String] $Uri,
 
+        [Parameter(Position = 1)]
+        [ValidateNotNullOrEmpty()]
+        [System.String] $UserAgent = $script:resourceStrings.UserAgent.Base,
+
         [Parameter()]
         [ValidateNotNullOrEmpty()]
         [System.Int32] $MaximumRedirection = 3
@@ -17,6 +21,7 @@ Function Invoke-SystemNetRequest {
 
     try {
         $httpWebRequest = [System.Net.WebRequest]::Create($Uri)
+        $httpWebRequest.UserAgent = $UserAgent
         $httpWebRequest.MaximumAutomaticRedirections = $MaximumRedirection
         $httpWebRequest.AllowAutoRedirect = $true
 

--- a/Evergreen/Private/Resolve-SystemNetWebRequest.ps1
+++ b/Evergreen/Private/Resolve-SystemNetWebRequest.ps1
@@ -20,30 +20,30 @@ function Resolve-SystemNetWebRequest {
         [System.Int32] $MaximumRedirection = 3
     )
 
-    $httpWebRequest = [System.Net.WebRequest]::Create($Uri)
-    $httpWebRequest.UserAgent = $UserAgent
-    $httpWebRequest.MaximumAutomaticRedirections = $MaximumRedirection
-    $httpWebRequest.AllowAutoRedirect = $true
-
-    if (Test-ProxyEnv) {
-        $ProxyObj = New-Object -TypeName "System.Net.WebProxy"
-        $ProxyObj.Address = $script:EvergreenProxy
-        $ProxyObj.UseDefaultCredentials = $true
-        $httpWebRequest.Proxy = $ProxyObj
-
-        if (Test-ProxyEnv -Creds) {
-            $ProxyObj.UseDefaultCredentials = $false
-            $ProxyObj.Credentials = $script:EvergreenProxyCreds
-            $httpWebRequest.UseDefaultCredentials = $false
-            $httpWebRequest.Proxy = $ProxyObj
-            $httpWebRequest.Credentials = $script:EvergreenProxyCreds
-        }
-    }
-    else {
-        $httpWebRequest.UseDefaultCredentials = $true
-    }
-
     try {
+        $httpWebRequest = [System.Net.WebRequest]::Create($Uri)
+        $httpWebRequest.UserAgent = $UserAgent
+        $httpWebRequest.MaximumAutomaticRedirections = $MaximumRedirection
+        $httpWebRequest.AllowAutoRedirect = $true
+
+        if (Test-ProxyEnv) {
+            $ProxyObj = New-Object -TypeName "System.Net.WebProxy"
+            $ProxyObj.Address = $script:EvergreenProxy
+            $ProxyObj.UseDefaultCredentials = $true
+            $httpWebRequest.Proxy = $ProxyObj
+
+            if (Test-ProxyEnv -Creds) {
+                $ProxyObj.UseDefaultCredentials = $false
+                $ProxyObj.Credentials = $script:EvergreenProxyCreds
+                $httpWebRequest.UseDefaultCredentials = $false
+                $httpWebRequest.Proxy = $ProxyObj
+                $httpWebRequest.Credentials = $script:EvergreenProxyCreds
+            }
+        }
+        else {
+            $httpWebRequest.UseDefaultCredentials = $true
+        }
+
         Write-Verbose -Message "$($MyInvocation.MyCommand): Attempting to resolve: $Uri."
         $webResponse = $httpWebRequest.GetResponse()
         Write-Verbose -Message "$($MyInvocation.MyCommand): Resolved to: [$($webResponse.ResponseUri.AbsoluteUri)]."

--- a/Evergreen/Public/Export-EvergreenManifest.ps1
+++ b/Evergreen/Public/Export-EvergreenManifest.ps1
@@ -7,6 +7,7 @@ function Export-EvergreenManifest {
     param (
         [Parameter(Mandatory = $true, Position = 0)]
         [ValidateNotNull()]
+        [Alias("ApplicationName")]
         [System.String] $Name
     )
 

--- a/Evergreen/Public/Export-EvergreenManifest.ps1
+++ b/Evergreen/Public/Export-EvergreenManifest.ps1
@@ -1,11 +1,11 @@
-Function Export-EvergreenManifest {
+function Export-EvergreenManifest {
     <#
         .EXTERNALHELP Evergreen-help.xml
     #>
     [OutputType([System.Management.Automation.PSObject])]
-    [CmdletBinding(SupportsShouldProcess = $False, HelpURI = "https://stealthpuppy.com/evergreen/")]
+    [CmdletBinding(SupportsShouldProcess = $false)]
     param (
-        [Parameter(Mandatory = $True, Position = 0)]
+        [Parameter(Mandatory = $true, Position = 0)]
         [ValidateNotNull()]
         [System.String] $Name
     )

--- a/Evergreen/Public/Find-EvergreenApp.ps1
+++ b/Evergreen/Public/Find-EvergreenApp.ps1
@@ -12,6 +12,7 @@
             ValueFromPipeline,
             HelpMessage = "Specify an a string to search from the list of supported applications.")]
         [ValidateNotNull()]
+        [Alias("ApplicationName")]
         [System.String] $Name
     )
 

--- a/Evergreen/Public/Find-EvergreenApp.ps1
+++ b/Evergreen/Public/Find-EvergreenApp.ps1
@@ -1,13 +1,13 @@
-﻿Function Find-EvergreenApp {
+﻿function Find-EvergreenApp {
     <#
         .EXTERNALHELP Evergreen-help.xml
     #>
     [OutputType([System.Management.Automation.PSObject])]
-    [CmdletBinding(SupportsShouldProcess = $False, HelpURI = "https://stealthpuppy.com/evergreen/find/")]
+    [CmdletBinding(SupportsShouldProcess = $false)]
     [Alias("fea")]
     param (
         [Parameter(
-            Mandatory = $False,
+            Mandatory = $false,
             Position = 0,
             ValueFromPipeline,
             HelpMessage = "Specify an a string to search from the list of supported applications.")]

--- a/Evergreen/Public/Get-EvergreenApp.ps1
+++ b/Evergreen/Public/Get-EvergreenApp.ps1
@@ -1,13 +1,13 @@
-Function Get-EvergreenApp {
+function Get-EvergreenApp {
     <#
         .EXTERNALHELP Evergreen-help.xml
     #>
     [OutputType([System.Management.Automation.PSObject])]
-    [CmdletBinding(SupportsShouldProcess = $True, HelpURI = "https://stealthpuppy.com/evergreen/use/")]
+    [CmdletBinding(SupportsShouldProcess = $true)]
     [Alias("gea")]
     param (
         [Parameter(
-            Mandatory = $True,
+            Mandatory = $true,
             Position = 0,
             ValueFromPipeline,
             ValueFromPipelineByPropertyName,
@@ -16,15 +16,15 @@ Function Get-EvergreenApp {
         [System.String] $Name,
 
         [Parameter(
-            Mandatory = $False,
+            Mandatory = $false,
             Position = 1,
             HelpMessage = "Specify a hashtable of parameters to pass to the internal application function.")]
         [System.Collections.Hashtable] $AppParams,
 
-        [Parameter(Mandatory = $False, Position = 2)]
+        [Parameter(Mandatory = $false, Position = 2)]
         [System.String] $Proxy,
 
-        [Parameter(Mandatory = $False, Position = 3)]
+        [Parameter(Mandatory = $false, Position = 3)]
         [System.Management.Automation.PSCredential]
         $ProxyCredential = [System.Management.Automation.PSCredential]::Empty,
 

--- a/Evergreen/Public/Get-EvergreenApp.ps1
+++ b/Evergreen/Public/Get-EvergreenApp.ps1
@@ -13,6 +13,7 @@ function Get-EvergreenApp {
             ValueFromPipelineByPropertyName,
             HelpMessage = "Specify an application name. Use Find-EvergreenApp to list supported applications.")]
         [ValidateNotNull()]
+        [Alias("ApplicationName")]
         [System.String] $Name,
 
         [Parameter(

--- a/Evergreen/Public/Get-EvergreenEndpoint.ps1
+++ b/Evergreen/Public/Get-EvergreenEndpoint.ps1
@@ -17,14 +17,14 @@ function Get-EvergreenEndpoint {
             Uri         = "https://evergreen-api.stealthpuppy.com/endpoints/versions"
             ErrorAction = "Stop"
         }
-        $Versions = Invoke-RestMethod @params
+        $Versions = Invoke-EvergreenRestMethod @params
 
         # Get the endpoints from the download URLs
         $params = @{
             Uri         = "https://evergreen-api.stealthpuppy.com/endpoints/downloads"
             ErrorAction = "Stop"
         }
-        $Downloads = Invoke-RestMethod @params
+        $Downloads = Invoke-EvergreenRestMethod @params
     }
     process {
         # Output the endpoints by joining the two queries

--- a/Evergreen/Public/Get-EvergreenEndpoint.ps1
+++ b/Evergreen/Public/Get-EvergreenEndpoint.ps1
@@ -8,6 +8,7 @@ function Get-EvergreenEndpoint {
             Position = 0,
             ValueFromPipeline,
             ValueFromPipelineByPropertyName)]
+        [Alias("ApplicationName")]
         [System.String[]] $Name
     )
 

--- a/Evergreen/Public/Get-EvergreenLibrary.ps1
+++ b/Evergreen/Public/Get-EvergreenLibrary.ps1
@@ -2,10 +2,10 @@ function Get-EvergreenLibrary {
     <#
         .EXTERNALHELP Evergreen-help.xml
     #>
-    [CmdletBinding(SupportsShouldProcess = $False)]
+    [CmdletBinding(SupportsShouldProcess = $false)]
     param (
         [Parameter(
-            Mandatory = $True,
+            Mandatory = $true,
             Position = 0,
             ValueFromPipelineByPropertyName,
             HelpMessage = "Specify the path to the library.",
@@ -33,7 +33,7 @@ function Get-EvergreenLibrary {
                     throw $_
                 }
 
-                if ($Null -ne $Library) {
+                if ($null -ne $Library) {
 
                     # Build the output object
                     $Output = [PSCustomObject] @{

--- a/Evergreen/Public/Get-EvergreenLibraryApp.ps1
+++ b/Evergreen/Public/Get-EvergreenLibraryApp.ps1
@@ -20,6 +20,7 @@ function Get-EvergreenLibraryApp {
             ValueFromPipelineByPropertyName,
             HelpMessage = "Specify an application name. Use Find-EvergreenApp to list supported applications.")]
         [ValidateNotNullOrEmpty()]
+        [Alias("ApplicationName")]
         [System.String] $Name
     )
 

--- a/Evergreen/Public/Invoke-EvergreenApp.ps1
+++ b/Evergreen/Public/Invoke-EvergreenApp.ps1
@@ -18,7 +18,6 @@ function Invoke-EvergreenApp {
 
     process {
         try {
-            Find-EvergreenApp -Name $Name | Out-Null
             $params = @{
                 Uri         = "https://evergreen-api.stealthpuppy.com/app/$Name"
                 ErrorAction = "Stop"

--- a/Evergreen/Public/Invoke-EvergreenApp.ps1
+++ b/Evergreen/Public/Invoke-EvergreenApp.ps1
@@ -1,10 +1,10 @@
-Function Invoke-EvergreenApp {
+function Invoke-EvergreenApp {
     <#
         .EXTERNALHELP Evergreen-help.xml
     #>
     [OutputType([System.Management.Automation.PSObject])]
-    [CmdletBinding(SupportsShouldProcess = $False, HelpURI = "https://stealthpuppy.com/evergreen/invoke/")]
-    [Alias("iea")]
+    [CmdletBinding(SupportsShouldProcess = $false)]
+    [Alias("iea", "Get-EvergreenAppFromApi")]
     param (
         [Parameter(
             Mandatory = $True,

--- a/Evergreen/Public/Invoke-EvergreenApp.ps1
+++ b/Evergreen/Public/Invoke-EvergreenApp.ps1
@@ -13,6 +13,7 @@ function Invoke-EvergreenApp {
             ValueFromPipelineByPropertyName,
             HelpMessage = "Specify an application name. Use Find-EvergreenApp to list supported applications.")]
         [ValidateNotNull()]
+        [Alias("ApplicationName")]
         [System.String] $Name
     )
 

--- a/Evergreen/Public/Invoke-EvergreenApp.ps1
+++ b/Evergreen/Public/Invoke-EvergreenApp.ps1
@@ -7,14 +7,14 @@ function Invoke-EvergreenApp {
     [Alias("iea", "Get-EvergreenAppFromApi")]
     param (
         [Parameter(
-            Mandatory = $True,
+            Mandatory = $false,
             Position = 0,
             ValueFromPipeline,
             ValueFromPipelineByPropertyName,
             HelpMessage = "Specify an application name. Use Find-EvergreenApp to list supported applications.")]
-        [ValidateNotNull()]
+        [ValidateNotNullOrEmpty()]
         [Alias("ApplicationName")]
-        [System.String] $Name
+        [System.String] $Name = "Microsoft365Apps"
     )
 
     process {

--- a/Evergreen/Public/Invoke-EvergreenLibraryUpdate.ps1
+++ b/Evergreen/Public/Invoke-EvergreenLibraryUpdate.ps1
@@ -2,10 +2,11 @@ function Invoke-EvergreenLibraryUpdate {
     <#
         .EXTERNALHELP Evergreen-help.xml
     #>
-    [CmdletBinding(SupportsShouldProcess = $True)]
+    [CmdletBinding(SupportsShouldProcess = $true)]
+    [Alias("Start-EvergreenLibraryUpdate")]
     param (
         [Parameter(
-            Mandatory = $True,
+            Mandatory = $true,
             Position = 0,
             ValueFromPipelineByPropertyName,
             HelpMessage = "Specify the path to the library.",

--- a/Evergreen/Public/New-EvergreenLibrary.ps1
+++ b/Evergreen/Public/New-EvergreenLibrary.ps1
@@ -2,10 +2,10 @@ function New-EvergreenLibrary {
     <#
         .EXTERNALHELP Evergreen-help.xml
     #>
-    [CmdletBinding(SupportsShouldProcess = $True)]
+    [CmdletBinding(SupportsShouldProcess = $true)]
     param (
         [Parameter(
-            Mandatory = $True,
+            Mandatory = $true,
             Position = 0,
             ValueFromPipelineByPropertyName,
             HelpMessage = "Specify the path to the library.",
@@ -14,7 +14,7 @@ function New-EvergreenLibrary {
         [System.IO.FileInfo] $Path,
 
         [Parameter(
-            Mandatory = $False,
+            Mandatory = $false,
             Position = 1,
             HelpMessage = "Specify a name for the library.",
             ParameterSetName = "Path")]

--- a/Evergreen/Public/New-EvergreenLibrary.ps1
+++ b/Evergreen/Public/New-EvergreenLibrary.ps1
@@ -19,6 +19,7 @@ function New-EvergreenLibrary {
             HelpMessage = "Specify a name for the library.",
             ParameterSetName = "Path")]
         [ValidateNotNull()]
+        [Alias("LibraryName")]
         [System.String] $Name = "EvergreenLibrary"
     )
 

--- a/Evergreen/Public/Save-EvergreenApp.ps1
+++ b/Evergreen/Public/Save-EvergreenApp.ps1
@@ -1,9 +1,9 @@
-Function Save-EvergreenApp {
+function Save-EvergreenApp {
     <#
         .EXTERNALHELP Evergreen-help.xml
     #>
     [OutputType([System.Management.Automation.PSObject])]
-    [CmdletBinding(SupportsShouldProcess = $true, HelpURI = "https://stealthpuppy.com/evergreen/save/", DefaultParameterSetName = "Path")]
+    [CmdletBinding(SupportsShouldProcess = $true, DefaultParameterSetName = "Path")]
     [Alias("sea")]
     param (
         [Parameter(

--- a/Evergreen/Public/Test-EvergreenApp.ps1
+++ b/Evergreen/Public/Test-EvergreenApp.ps1
@@ -1,13 +1,13 @@
-Function Test-EvergreenApp {
+function Test-EvergreenApp {
     <#
         .EXTERNALHELP Evergreen-help.xml
     #>
     [OutputType([System.Management.Automation.PSObject])]
-    [CmdletBinding(SupportsShouldProcess = $True, HelpURI = "https://stealthpuppy.com/evergreen/test/", DefaultParameterSetName = "Path")]
+    [CmdletBinding(SupportsShouldProcess = $true, DefaultParameterSetName = "Path")]
     [Alias("tea")]
     param (
         [Parameter(
-            Mandatory = $True,
+            Mandatory = $true,
             Position = 0,
             ValueFromPipeline,
             HelpMessage = "Pass an application object from Get-EvergreenApp.")]
@@ -17,7 +17,7 @@ Function Test-EvergreenApp {
         [Parameter(Mandatory = $False, Position = 1)]
         [System.String] $Proxy,
 
-        [Parameter(Mandatory = $False, Position = 2)]
+        [Parameter(Mandatory = $false, Position = 2)]
         [System.Management.Automation.PSCredential]
         $ProxyCredential = [System.Management.Automation.PSCredential]::Empty,
 
@@ -25,10 +25,10 @@ Function Test-EvergreenApp {
         [ValidateNotNullOrEmpty()]
         [System.String] $UserAgent = $script:resourceStrings.UserAgent.Base,
 
-        [Parameter(Mandatory = $False)]
+        [Parameter(Mandatory = $false)]
         [System.Management.Automation.SwitchParameter] $Force,
 
-        [Parameter(Mandatory = $False)]
+        [Parameter(Mandatory = $false)]
         [System.Management.Automation.SwitchParameter] $NoProgress
     )
 

--- a/Evergreen/Shared/Get-GitHubRepoRelease.ps1
+++ b/Evergreen/Shared/Get-GitHubRepoRelease.ps1
@@ -187,7 +187,7 @@ function Get-GitHubRepoRelease {
                             $PSObject = [PSCustomObject] @{
                                 Version       = $Version
                                 Platform      = Get-Platform -String $asset.browser_download_url
-                                Architecture  = Get-Architecture -String $asset.browser_download_url
+                                Architecture  = Get-Architecture -String $(Split-Path -Path $asset.browser_download_url -Leaf)
                                 Type          = [System.IO.Path]::GetExtension($asset.browser_download_url).Split(".")[-1]
                                 InstallerType = Get-InstallerType -String $asset.browser_download_url
                                 Date          = ConvertTo-DateTime -DateTime $item.created_at -Pattern "MM/dd/yyyy HH:mm:ss"

--- a/Evergreen/en-US/Evergreen-help.xml
+++ b/Evergreen/en-US/Evergreen-help.xml
@@ -359,7 +359,7 @@ Export-EvergreenApp -InputObject $OneDrive -Path "C:\Evergreen\OneDrive\Microsof
     <maml:description>
       <maml:para>Queries the internal application functions and manifests included in the module to find the latest version and download link/s for the specified application.</maml:para>
       <maml:para>The output from this function can be passed to Where-Object to filter for a specific download based on properties including processor architecture, file type or other properties.</maml:para>
-      <maml:para>`Get-EvergreenApp` uses official vendor sites including update APIs, web queries, and code repository locations to return details of a target application at run time.</maml:para>
+      <maml:para>`Get-EvergreenApp` uses official vendor sources including update APIs, web queries, and code repository locations to return details of a target application at run time.</maml:para>
     </maml:description>
     <command:syntax>
       <command:syntaxItem>
@@ -1017,11 +1017,11 @@ Architecture : x64</dev:code>
       <command:verb>Invoke</command:verb>
       <command:noun>EvergreenApp</command:noun>
       <maml:description>
-        <maml:para>Returns the latest version and download URL/s for an application supported by the Evergreen module. This function queries an API that is updated by Get-EvergreenApp every 8 hours.</maml:para>
+        <maml:para>Returns the latest version and download URL/s for an application supported by the Evergreen module. This function returns the same data as Get-EvergreenApp, but queries the Evergreen App Tracker API for this data.</maml:para>
       </maml:description>
     </command:details>
     <maml:description>
-      <maml:para>Returns the latest version and download URL/s for an application supported by the Evergreen module. This function queries an API that is updated by Get-EvergreenApp every 8 hours. This function is experimental and functionality may change - do not use in production.</maml:para>
+      <maml:para>Returns the latest version and download URL/s for an application supported by the Evergreen module. This function returns the same data as Get-EvergreenApp, but queries the Evergreen App Tracker API for this data. Data for the API is from a key/value store updated by Get-EvergreenApp every 12-hours.</maml:para>
     </maml:description>
     <command:syntax>
       <command:syntaxItem>

--- a/Evergreen/en-US/Evergreen-help.xml
+++ b/Evergreen/en-US/Evergreen-help.xml
@@ -126,7 +126,9 @@
     <command:returnValues />
     <maml:alertSet>
       <maml:alert>
-        <maml:para>Site: https://stealthpuppy.com Author: Aaron Parker Twitter: @stealthpuppy</maml:para>
+        <maml:para>Site: https://stealthpuppy.com</maml:para>
+        <maml:para>Author: Aaron Parker</maml:para>
+        <maml:para>Twitter: @stealthpuppy</maml:para>
       </maml:alert>
     </maml:alertSet>
     <command:examples>
@@ -142,8 +144,12 @@ Export-EvergreenApp -InputObject $OneDrive -Path "C:\Evergreen\OneDrive\Microsof
     </command:examples>
     <command:relatedLinks>
       <maml:navigationLink>
-        <maml:linkText>Export application version information:</maml:linkText>
-        <maml:uri>https://stealthpuppy.com/evergreen/export.html</maml:uri>
+        <maml:linkText>Online Version:</maml:linkText>
+        <maml:uri>https://stealthpuppy.com/evergreen/help/en-US/Export-EvergreenApp/</maml:uri>
+      </maml:navigationLink>
+      <maml:navigationLink>
+        <maml:linkText>Export application version information</maml:linkText>
+        <maml:uri>https://stealthpuppy.com/evergreen/export/</maml:uri>
       </maml:navigationLink>
     </command:relatedLinks>
   </command:command>
@@ -212,7 +218,9 @@ Export-EvergreenApp -InputObject $OneDrive -Path "C:\Evergreen\OneDrive\Microsof
     </command:returnValues>
     <maml:alertSet>
       <maml:alert>
-        <maml:para>Site: https://stealthpuppy.com Author: Aaron Parker Twitter: @stealthpuppy</maml:para>
+        <maml:para>Site: https://stealthpuppy.com</maml:para>
+        <maml:para>Author: Aaron Parker</maml:para>
+        <maml:para>Twitter: @stealthpuppy</maml:para>
       </maml:alert>
     </maml:alertSet>
     <command:examples>
@@ -226,7 +234,11 @@ Export-EvergreenApp -InputObject $OneDrive -Path "C:\Evergreen\OneDrive\Microsof
     </command:examples>
     <command:relatedLinks>
       <maml:navigationLink>
-        <maml:linkText>Getting started with Evergreen:</maml:linkText>
+        <maml:linkText>Online Version:</maml:linkText>
+        <maml:uri>https://stealthpuppy.com/evergreen/help/en-US/Export-EvergreenManifest/</maml:uri>
+      </maml:navigationLink>
+      <maml:navigationLink>
+        <maml:linkText>Getting started with Evergreen</maml:linkText>
         <maml:uri>https://stealthpuppy.com/evergreen/</maml:uri>
       </maml:navigationLink>
     </command:relatedLinks>
@@ -296,7 +308,9 @@ Export-EvergreenApp -InputObject $OneDrive -Path "C:\Evergreen\OneDrive\Microsof
     </command:returnValues>
     <maml:alertSet>
       <maml:alert>
-        <maml:para>Site: https://stealthpuppy.com Author: Aaron Parker Twitter: @stealthpuppy</maml:para>
+        <maml:para>Site: https://stealthpuppy.com</maml:para>
+        <maml:para>Author: Aaron Parker</maml:para>
+        <maml:para>Twitter: @stealthpuppy</maml:para>
       </maml:alert>
     </maml:alertSet>
     <command:examples>
@@ -324,8 +338,12 @@ Export-EvergreenApp -InputObject $OneDrive -Path "C:\Evergreen\OneDrive\Microsof
     </command:examples>
     <command:relatedLinks>
       <maml:navigationLink>
-        <maml:linkText>Find supported applications:</maml:linkText>
-        <maml:uri>https://stealthpuppy.com/evergreen/find.html</maml:uri>
+        <maml:linkText>Online Version:</maml:linkText>
+        <maml:uri>https://stealthpuppy.com/evergreen/help/en-US/Find-EvergreenApp/</maml:uri>
+      </maml:navigationLink>
+      <maml:navigationLink>
+        <maml:linkText>Find supported applications</maml:linkText>
+        <maml:uri>https://stealthpuppy.com/evergreen/find/</maml:uri>
       </maml:navigationLink>
     </command:relatedLinks>
   </command:command>
@@ -543,7 +561,9 @@ Export-EvergreenApp -InputObject $OneDrive -Path "C:\Evergreen\OneDrive\Microsof
     </command:returnValues>
     <maml:alertSet>
       <maml:alert>
-        <maml:para>Site: https://stealthpuppy.com Author: Aaron Parker Twitter: @stealthpuppy</maml:para>
+        <maml:para>Site: https://stealthpuppy.com</maml:para>
+        <maml:para>Author: Aaron Parker</maml:para>
+        <maml:para>Twitter: @stealthpuppy</maml:para>
       </maml:alert>
     </maml:alertSet>
     <command:examples>
@@ -616,8 +636,12 @@ URI          : https://msedge.sf.dl.delivery.mp.microsoft.com/filestreamingservi
     </command:examples>
     <command:relatedLinks>
       <maml:navigationLink>
-        <maml:linkText>Use Evergreen:</maml:linkText>
-        <maml:uri>https://stealthpuppy.com/evergreen/use.html</maml:uri>
+        <maml:linkText>Online Version:</maml:linkText>
+        <maml:uri>https://stealthpuppy.com/evergreen/help/en-US/Get-EvergreenApp/</maml:uri>
+      </maml:navigationLink>
+      <maml:navigationLink>
+        <maml:linkText>Use Evergreen</maml:linkText>
+        <maml:uri>https://stealthpuppy.com/evergreen/use/</maml:uri>
       </maml:navigationLink>
     </command:relatedLinks>
   </command:command>
@@ -687,7 +711,9 @@ URI          : https://msedge.sf.dl.delivery.mp.microsoft.com/filestreamingservi
     </command:returnValues>
     <maml:alertSet>
       <maml:alert>
-        <maml:para>Site: https://stealthpuppy.com Author: Aaron Parker Twitter: @stealthpuppy</maml:para>
+        <maml:para>Site: https://stealthpuppy.com</maml:para>
+        <maml:para>Author: Aaron Parker</maml:para>
+        <maml:para>Twitter: @stealthpuppy</maml:para>
       </maml:alert>
     </maml:alertSet>
     <command:examples>
@@ -734,8 +760,12 @@ c.1password.com</dev:code>
     </command:examples>
     <command:relatedLinks>
       <maml:navigationLink>
-        <maml:linkText>Use Evergreen:</maml:linkText>
-        <maml:uri>https://stealthpuppy.com/evergreen/use.html</maml:uri>
+        <maml:linkText>Online Version:</maml:linkText>
+        <maml:uri>https://stealthpuppy.com/evergreen/help/en-US/Get-EvergreenEndpoint/</maml:uri>
+      </maml:navigationLink>
+      <maml:navigationLink>
+        <maml:linkText>Retrieve endpoints used by Evergreen</maml:linkText>
+        <maml:uri>https://stealthpuppy.com/evergreen/endpoints/</maml:uri>
       </maml:navigationLink>
     </command:relatedLinks>
   </command:command>
@@ -804,7 +834,9 @@ c.1password.com</dev:code>
     </command:returnValues>
     <maml:alertSet>
       <maml:alert>
-        <maml:para>Site: https://stealthpuppy.com Author: Aaron Parker Twitter: @stealthpuppy</maml:para>
+        <maml:para>Site: https://stealthpuppy.com</maml:para>
+        <maml:para>Author: Aaron Parker</maml:para>
+        <maml:para>Twitter: @stealthpuppy</maml:para>
       </maml:alert>
     </maml:alertSet>
     <command:examples>
@@ -812,13 +844,17 @@ c.1password.com</dev:code>
         <maml:title>-------------------------- Example 1 --------------------------</maml:title>
         <dev:code>PS C:\&gt; Get-EvergreenLibrary -Path "\\server\EvergreenLibrary"</dev:code>
         <dev:remarks>
-          <maml:para>Returns details about the Evergreen library at \\server\EvergreenLibrary, including application version information stored for each application.</maml:para>
+          <maml:para>Returns details about the Evergreen library at \server\EvergreenLibrary, including application version information stored for each application.</maml:para>
         </dev:remarks>
       </command:example>
     </command:examples>
     <command:relatedLinks>
       <maml:navigationLink>
-        <maml:linkText>Create an Evergreen library:</maml:linkText>
+        <maml:linkText>Online Version:</maml:linkText>
+        <maml:uri>https://stealthpuppy.com/evergreen/help/en-US/Get-EvergreenLibrary/</maml:uri>
+      </maml:navigationLink>
+      <maml:navigationLink>
+        <maml:linkText>Create an Evergreen library</maml:linkText>
         <maml:uri>https://stealthpuppy.com/evergreen/getlibrary.html</maml:uri>
       </maml:navigationLink>
     </command:relatedLinks>
@@ -912,7 +948,9 @@ c.1password.com</dev:code>
     </command:returnValues>
     <maml:alertSet>
       <maml:alert>
-        <maml:para>Site: https://stealthpuppy.com Author: Aaron Parker Twitter: @stealthpuppy</maml:para>
+        <maml:para>Site: https://stealthpuppy.com</maml:para>
+        <maml:para>Author: Aaron Parker</maml:para>
+        <maml:para>Twitter: @stealthpuppy</maml:para>
       </maml:alert>
     </maml:alertSet>
     <command:examples>
@@ -936,7 +974,7 @@ Path         : \\server\EvergreenLibrary\MicrosoftVisualStudioCode\Stable\1.74.3
 Channel      : Stable
 Architecture : x64</dev:code>
         <dev:remarks>
-          <maml:para>Returns details about Microsoft Visual Studio Code from the Evergreen library at \\server\EvergreenLibrary that is sent to Get-EvergreenLibraryApp from Get-EvergreenLibrary via the pipeline.</maml:para>
+          <maml:para>Returns details about Microsoft Visual Studio Code from the Evergreen library at \server\EvergreenLibrary that is sent to Get-EvergreenLibraryApp from Get-EvergreenLibrary via the pipeline.</maml:para>
         </dev:remarks>
       </command:example>
       <command:example>
@@ -958,14 +996,14 @@ Ring         : General
 Path         : \\server\EvergreenLibrary\MicrosoftTeams\General\1.5.00.31168\x64\Teams_windows_x64.msi
 Architecture : x64</dev:code>
         <dev:remarks>
-          <maml:para>Uses Get-EvergreenLibrary to place details about the Evergreen library at \\server\EvergreenLibrary into an object called $Library, which is then used on the command line for Get-EvergreenLibraryApp to return details about Microsoft Teams.</maml:para>
+          <maml:para>Uses Get-EvergreenLibrary to place details about the Evergreen library at \server\EvergreenLibrary into an object called $Library, which is then used on the command line for Get-EvergreenLibraryApp to return details about Microsoft Teams.</maml:para>
         </dev:remarks>
       </command:example>
     </command:examples>
     <command:relatedLinks>
       <maml:navigationLink>
         <maml:linkText>Online Version:</maml:linkText>
-        <maml:uri>https://stealthpuppy.com/evergreen/getlibraryapp.html</maml:uri>
+        <maml:uri>https://stealthpuppy.com/evergreen/help/en-US/Get-EvergreenLibraryApp/</maml:uri>
       </maml:navigationLink>
       <maml:navigationLink>
         <maml:linkText>Create an Evergreen library:</maml:linkText>
@@ -1038,7 +1076,9 @@ Architecture : x64</dev:code>
     </command:returnValues>
     <maml:alertSet>
       <maml:alert>
-        <maml:para>Site: https://stealthpuppy.com Author: Aaron Parker Twitter: @stealthpuppy</maml:para>
+        <maml:para>Site: https://stealthpuppy.com</maml:para>
+        <maml:para>Author: Aaron Parker</maml:para>
+        <maml:para>Twitter: @stealthpuppy</maml:para>
       </maml:alert>
     </maml:alertSet>
     <command:examples>
@@ -1067,6 +1107,10 @@ URI          : https://msedge.sf.dl.delivery.mp.microsoft.com/filestreamingservi
       </command:example>
     </command:examples>
     <command:relatedLinks>
+      <maml:navigationLink>
+        <maml:linkText>Online Version:</maml:linkText>
+        <maml:uri>https://stealthpuppy.com/evergreen/help/en-US/Invoke-EvergreenApp/</maml:uri>
+      </maml:navigationLink>
       <maml:navigationLink>
         <maml:linkText>https://stealthpuppy.com/evergreen/invoke/</maml:linkText>
         <maml:uri>https://stealthpuppy.com/evergreen/invoke/</maml:uri>
@@ -1228,7 +1272,9 @@ URI          : https://msedge.sf.dl.delivery.mp.microsoft.com/filestreamingservi
     <command:returnValues />
     <maml:alertSet>
       <maml:alert>
-        <maml:para>Site: https://stealthpuppy.com Author: Aaron Parker Twitter: @stealthpuppy</maml:para>
+        <maml:para>Site: https://stealthpuppy.com</maml:para>
+        <maml:para>Author: Aaron Parker</maml:para>
+        <maml:para>Twitter: @stealthpuppy</maml:para>
       </maml:alert>
     </maml:alertSet>
     <command:examples>
@@ -1236,14 +1282,18 @@ URI          : https://msedge.sf.dl.delivery.mp.microsoft.com/filestreamingservi
         <maml:title>-------------------------- EXAMPLE 1 --------------------------</maml:title>
         <dev:code>Invoke-EvergreenLibraryUpdate -Path "\\server\EvergreenLibrary"</dev:code>
         <dev:remarks>
-          <maml:para>Description: `Invoke-EvergreenLibraryUpdate` reads the library manifest `EvergreenLibrary.json` located in \\server\EvergreenLibrary which defines the applications for that library. It uses `Get-EvergreenApp` and `Save-EvergreenApp` to download the latest installers to the library.</maml:para>
+          <maml:para>Description: `Invoke-EvergreenLibraryUpdate` reads the library manifest `EvergreenLibrary.json` located in \server\EvergreenLibrary which defines the applications for that library. It uses `Get-EvergreenApp` and `Save-EvergreenApp` to download the latest installers to the library.</maml:para>
         </dev:remarks>
       </command:example>
     </command:examples>
     <command:relatedLinks>
       <maml:navigationLink>
-        <maml:linkText>Update an Evergreen library:</maml:linkText>
-        <maml:uri>https://stealthpuppy.com/evergreen/updatelibrary.html</maml:uri>
+        <maml:linkText>Online Version:</maml:linkText>
+        <maml:uri>https://stealthpuppy.com/evergreen/help/en-US/Invoke-EvergreenLibraryUpdate/</maml:uri>
+      </maml:navigationLink>
+      <maml:navigationLink>
+        <maml:linkText>Update an Evergreen library</maml:linkText>
+        <maml:uri>https://stealthpuppy.com/evergreen/updatelibrary/</maml:uri>
       </maml:navigationLink>
     </command:relatedLinks>
   </command:command>
@@ -1381,21 +1431,25 @@ URI          : https://msedge.sf.dl.delivery.mp.microsoft.com/filestreamingservi
         <maml:title>-------------------------- EXAMPLE 1 --------------------------</maml:title>
         <dev:code>New-EvergreenLibrary -Path "\\server\EvergreenLibrary"</dev:code>
         <dev:remarks>
-          <maml:para>Description: Creates a new Evergreen library in the path \\server\EvergreenLibrary.</maml:para>
+          <maml:para>Description: Creates a new Evergreen library in the path \server\EvergreenLibrary.</maml:para>
         </dev:remarks>
       </command:example>
       <command:example>
         <maml:title>-------------------------- EXAMPLE 2 --------------------------</maml:title>
         <dev:code>New-EvergreenLibrary -Path "\\server\EvergreenLibrary" -Name "AzureVirtualDesktopProd"</dev:code>
         <dev:remarks>
-          <maml:para>Description: Creates a new Evergreen library in the path \\server\EvergreenLibrary. Assigns the name AzureVirtualDesktopProd to the manifest file - `EvergreenLibrary.json`.</maml:para>
+          <maml:para>Description: Creates a new Evergreen library in the path \server\EvergreenLibrary. Assigns the name AzureVirtualDesktopProd to the manifest file - `EvergreenLibrary.json`.</maml:para>
         </dev:remarks>
       </command:example>
     </command:examples>
     <command:relatedLinks>
       <maml:navigationLink>
+        <maml:linkText>Online Version:</maml:linkText>
+        <maml:uri>https://stealthpuppy.com/evergreen/help/en-US/New-EvergreenLibrary/</maml:uri>
+      </maml:navigationLink>
+      <maml:navigationLink>
         <maml:linkText>Create an Evergreen library:</maml:linkText>
-        <maml:uri>https://stealthpuppy.com/evergreen/newlibrary.html</maml:uri>
+        <maml:uri>https://stealthpuppy.com/evergreen/newlibrary/</maml:uri>
       </maml:navigationLink>
     </command:relatedLinks>
   </command:command>
@@ -1792,7 +1846,9 @@ URI          : https://msedge.sf.dl.delivery.mp.microsoft.com/filestreamingservi
     </command:returnValues>
     <maml:alertSet>
       <maml:alert>
-        <maml:para>Site: https://stealthpuppy.com Author: Aaron Parker Twitter: @stealthpuppy</maml:para>
+        <maml:para>Site: https://stealthpuppy.com</maml:para>
+        <maml:para>Author: Aaron Parker</maml:para>
+        <maml:para>Twitter: @stealthpuppy</maml:para>
       </maml:alert>
     </maml:alertSet>
     <command:examples>
@@ -1813,8 +1869,12 @@ URI          : https://msedge.sf.dl.delivery.mp.microsoft.com/filestreamingservi
     </command:examples>
     <command:relatedLinks>
       <maml:navigationLink>
+        <maml:linkText>Online Version:</maml:linkText>
+        <maml:uri>https://stealthpuppy.com/evergreen/help/en-US/Save-EvergreenApp/</maml:uri>
+      </maml:navigationLink>
+      <maml:navigationLink>
         <maml:linkText>Download application installers:</maml:linkText>
-        <maml:uri>https://stealthpuppy.com/evergreen/save.html</maml:uri>
+        <maml:uri>https://stealthpuppy.com/evergreen/save</maml:uri>
       </maml:navigationLink>
     </command:relatedLinks>
   </command:command>
@@ -2059,7 +2119,9 @@ URI          : https://msedge.sf.dl.delivery.mp.microsoft.com/filestreamingservi
     </command:returnValues>
     <maml:alertSet>
       <maml:alert>
-        <maml:para>Site: https://stealthpuppy.com Author: Aaron Parker Twitter: @stealthpuppy</maml:para>
+        <maml:para>Site: https://stealthpuppy.com</maml:para>
+        <maml:para>Author: Aaron Parker</maml:para>
+        <maml:para>Twitter: @stealthpuppy</maml:para>
       </maml:alert>
     </maml:alertSet>
     <command:examples>
@@ -2073,8 +2135,12 @@ URI          : https://msedge.sf.dl.delivery.mp.microsoft.com/filestreamingservi
     </command:examples>
     <command:relatedLinks>
       <maml:navigationLink>
-        <maml:linkText>Download application installers:</maml:linkText>
-        <maml:uri>https://stealthpuppy.com/evergreen/test.html</maml:uri>
+        <maml:linkText>Online Version:</maml:linkText>
+        <maml:uri>https://stealthpuppy.com/evergreen/help/en-US/Save-EvergreenApp/</maml:uri>
+      </maml:navigationLink>
+      <maml:navigationLink>
+        <maml:linkText>Test installers</maml:linkText>
+        <maml:uri>https://stealthpuppy.com/evergreen/test/</maml:uri>
       </maml:navigationLink>
     </command:relatedLinks>
   </command:command>

--- a/docs/help/en-US/Export-EvergreenApp.md
+++ b/docs/help/en-US/Export-EvergreenApp.md
@@ -1,7 +1,7 @@
 ---
 external help file: Evergreen-help.xml
 Module Name: Evergreen
-online version: https://stealthpuppy.com/evergreen/export.html
+online version: https://stealthpuppy.com/evergreen/help/en-US/Export-EvergreenApp/
 schema: 2.0.0
 ---
 
@@ -115,9 +115,11 @@ Export-EvergreenApp accepts the output from Get-EvergreenApp.
 ## NOTES
 
 Site: https://stealthpuppy.com
+
 Author: Aaron Parker
+
 Twitter: @stealthpuppy
 
 ## RELATED LINKS
 
-[Export application version information:](https://stealthpuppy.com/evergreen/export.html)
+[Export application version information](https://stealthpuppy.com/evergreen/export/)

--- a/docs/help/en-US/Export-EvergreenManifest.md
+++ b/docs/help/en-US/Export-EvergreenManifest.md
@@ -1,7 +1,7 @@
 ---
 external help file: Evergreen-help.xml
 Module Name: Evergreen
-online version: https://stealthpuppy.com/evergreen/
+online version: https://stealthpuppy.com/evergreen/help/en-US/Export-EvergreenManifest/
 schema: 2.0.0
 ---
 
@@ -65,9 +65,11 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 Site: https://stealthpuppy.com
+
 Author: Aaron Parker
+
 Twitter: @stealthpuppy
 
 ## RELATED LINKS
 
-[Getting started with Evergreen:](https://stealthpuppy.com/evergreen/)
+[Getting started with Evergreen](https://stealthpuppy.com/evergreen/)

--- a/docs/help/en-US/Find-EvergreenApp.md
+++ b/docs/help/en-US/Find-EvergreenApp.md
@@ -1,7 +1,7 @@
 ---
 external help file: Evergreen-help.xml
 Module Name: Evergreen
-online version: https://stealthpuppy.com/evergreen/find.html
+online version: https://stealthpuppy.com/evergreen/help/en-US/Find-EvergreenApp/
 schema: 2.0.0
 ---
 
@@ -84,9 +84,11 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 Site: https://stealthpuppy.com
+
 Author: Aaron Parker
+
 Twitter: @stealthpuppy
 
 ## RELATED LINKS
 
-[Find supported applications:](https://stealthpuppy.com/evergreen/find.html)
+[Find supported applications](https://stealthpuppy.com/evergreen/find/)

--- a/docs/help/en-US/Get-EvergreenApp.md
+++ b/docs/help/en-US/Get-EvergreenApp.md
@@ -1,7 +1,7 @@
 ---
 external help file: Evergreen-help.xml
 Module Name: Evergreen
-online version: https://stealthpuppy.com/evergreen/use.html
+online version: https://stealthpuppy.com/evergreen/help/en-US/Get-EvergreenApp/
 schema: 2.0.0
 ---
 
@@ -247,9 +247,11 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 Site: https://stealthpuppy.com
+
 Author: Aaron Parker
+
 Twitter: @stealthpuppy
 
 ## RELATED LINKS
 
-[Use Evergreen:](https://stealthpuppy.com/evergreen/use.html)
+[Use Evergreen](https://stealthpuppy.com/evergreen/use/)

--- a/docs/help/en-US/Get-EvergreenApp.md
+++ b/docs/help/en-US/Get-EvergreenApp.md
@@ -24,7 +24,7 @@ Queries the internal application functions and manifests included in the module 
 
 The output from this function can be passed to Where-Object to filter for a specific download based on properties including processor architecture, file type or other properties.
 
-`Get-EvergreenApp` uses official vendor sites including update APIs, web queries, and code repository locations to return details of a target application at run time.
+`Get-EvergreenApp` uses official vendor sources including update APIs, web queries, and code repository locations to return details of a target application at run time.
 
 ## EXAMPLES
 

--- a/docs/help/en-US/Get-EvergreenEndpoint.md
+++ b/docs/help/en-US/Get-EvergreenEndpoint.md
@@ -1,7 +1,7 @@
 ---
 external help file: Evergreen-help.xml
 Module Name: Evergreen
-online version: https://stealthpuppy.com/evergreen/use.html
+online version: https://stealthpuppy.com/evergreen/help/en-US/Get-EvergreenEndpoint/
 schema: 2.0.0
 ---
 
@@ -105,9 +105,11 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 Site: https://stealthpuppy.com
+
 Author: Aaron Parker
+
 Twitter: @stealthpuppy
 
 ## RELATED LINKS
 
-[Use Evergreen:](https://stealthpuppy.com/evergreen/use.html)
+[Retrieve endpoints used by Evergreen](https://stealthpuppy.com/evergreen/endpoints/)

--- a/docs/help/en-US/Get-EvergreenLibrary.md
+++ b/docs/help/en-US/Get-EvergreenLibrary.md
@@ -1,7 +1,7 @@
 ---
 external help file: Evergreen-help.xml
 Module Name: Evergreen
-online version: https://stealthpuppy.com/evergreen/getlibrary.html
+online version: https://stealthpuppy.com/evergreen/help/en-US/Get-EvergreenLibrary/
 schema: 2.0.0
 ---
 
@@ -64,9 +64,11 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 Site: https://stealthpuppy.com
+
 Author: Aaron Parker
+
 Twitter: @stealthpuppy
 
 ## RELATED LINKS
 
-[Create an Evergreen library:](https://stealthpuppy.com/evergreen/getlibrary.html)
+[Create an Evergreen library](https://stealthpuppy.com/evergreen/getlibrary.html)

--- a/docs/help/en-US/Get-EvergreenLibraryApp.md
+++ b/docs/help/en-US/Get-EvergreenLibraryApp.md
@@ -1,7 +1,7 @@
 ---
 external help file: Evergreen-help.xml
 Module Name: Evergreen
-online version: https://stealthpuppy.com/evergreen/getlibraryapp.html
+online version: https://stealthpuppy.com/evergreen/help/en-US/Get-EvergreenLibraryApp/
 schema: 2.0.0
 ---
 
@@ -120,7 +120,9 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 Site: https://stealthpuppy.com
+
 Author: Aaron Parker
+
 Twitter: @stealthpuppy
 
 ## RELATED LINKS

--- a/docs/help/en-US/Invoke-EvergreenApp.md
+++ b/docs/help/en-US/Invoke-EvergreenApp.md
@@ -9,7 +9,7 @@ schema: 2.0.0
 
 ## SYNOPSIS
 
-Returns the latest version and download URL/s for an application supported by the Evergreen module. This function queries an API that is updated by Get-EvergreenApp every 8 hours.
+Returns the latest version and download URL/s for an application supported by the Evergreen module. This function returns the same data as Get-EvergreenApp, but queries the Evergreen App Tracker API for this data.
 
 ## SYNTAX
 
@@ -19,7 +19,7 @@ Invoke-EvergreenApp [-Name] <String> [<CommonParameters>]
 
 ## DESCRIPTION
 
-Returns the latest version and download URL/s for an application supported by the Evergreen module. This function queries an API that is updated by Get-EvergreenApp every 8 hours. This function is experimental and functionality may change - do not use in production.
+Returns the latest version and download URL/s for an application supported by the Evergreen module. This function returns the same data as Get-EvergreenApp, but queries the Evergreen App Tracker API for this data. Data for the API is from a key/value store updated by Get-EvergreenApp every 12-hours.
 
 ## EXAMPLES
 

--- a/docs/help/en-US/Invoke-EvergreenApp.md
+++ b/docs/help/en-US/Invoke-EvergreenApp.md
@@ -1,7 +1,7 @@
 ---
 external help file: Evergreen-help.xml
 Module Name: Evergreen
-online version: https://stealthpuppy.com/evergreen/invoke/
+online version: https://stealthpuppy.com/evergreen/help/en-US/Invoke-EvergreenApp/
 schema: 2.0.0
 ---
 
@@ -84,7 +84,9 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 Site: https://stealthpuppy.com
+
 Author: Aaron Parker
+
 Twitter: @stealthpuppy
 
 ## RELATED LINKS

--- a/docs/help/en-US/Invoke-EvergreenLibraryUpdate.md
+++ b/docs/help/en-US/Invoke-EvergreenLibraryUpdate.md
@@ -1,7 +1,7 @@
 ---
 external help file: Evergreen-help.xml
 Module Name: Evergreen
-online version: https://stealthpuppy.com/evergreen/updatelibrary.html
+online version: https://stealthpuppy.com/evergreen/help/en-US/Invoke-EvergreenLibraryUpdate/
 schema: 2.0.0
 ---
 
@@ -136,9 +136,11 @@ Invoke-EvergreenLibraryUpdate accepts a string parameter.
 ## NOTES
 
 Site: https://stealthpuppy.com
+
 Author: Aaron Parker
+
 Twitter: @stealthpuppy
 
 ## RELATED LINKS
 
-[Update an Evergreen library:](https://stealthpuppy.com/evergreen/updatelibrary.html)
+[Update an Evergreen library](https://stealthpuppy.com/evergreen/updatelibrary/)

--- a/docs/help/en-US/New-EvergreenLibrary.md
+++ b/docs/help/en-US/New-EvergreenLibrary.md
@@ -1,7 +1,7 @@
 ---
 external help file: Evergreen-help.xml
 Module Name: Evergreen
-online version: https://stealthpuppy.com/evergreen/newlibrary.html
+online version: https://stealthpuppy.com/evergreen/help/en-US/New-EvergreenLibrary/
 schema: 2.0.0
 ---
 
@@ -127,4 +127,4 @@ Twitter: @stealthpuppy
 
 ## RELATED LINKS
 
-[Create an Evergreen library:](https://stealthpuppy.com/evergreen/newlibrary.html)
+[Create an Evergreen library:](https://stealthpuppy.com/evergreen/newlibrary/)

--- a/docs/help/en-US/Save-EvergreenApp.md
+++ b/docs/help/en-US/Save-EvergreenApp.md
@@ -1,7 +1,7 @@
 ---
 external help file: Evergreen-help.xml
 Module Name: Evergreen
-online version: https://stealthpuppy.com/evergreen/save.html
+online version: https://stealthpuppy.com/evergreen/help/en-US/Save-EvergreenApp/
 schema: 2.0.0
 ---
 
@@ -251,9 +251,11 @@ Provides a list of paths of the downloaded target files.
 ## NOTES
 
 Site: https://stealthpuppy.com
+
 Author: Aaron Parker
+
 Twitter: @stealthpuppy
 
 ## RELATED LINKS
 
-[Download application installers:](https://stealthpuppy.com/evergreen/save.html)
+[Download application installers:](https://stealthpuppy.com/evergreen/save)

--- a/docs/help/en-US/Test-EvergreenApp.md
+++ b/docs/help/en-US/Test-EvergreenApp.md
@@ -1,7 +1,7 @@
 ---
 external help file: Evergreen-help.xml
 Module Name: Evergreen
-online version: https://stealthpuppy.com/evergreen/test.html
+online version: https://stealthpuppy.com/evergreen/help/en-US/Save-EvergreenApp/
 schema: 2.0.0
 ---
 
@@ -195,9 +195,11 @@ Provides a list URLs and a true/false result.
 ## NOTES
 
 Site: https://stealthpuppy.com
+
 Author: Aaron Parker
+
 Twitter: @stealthpuppy
 
 ## RELATED LINKS
 
-[Download application installers:](https://stealthpuppy.com/evergreen/test.html)
+[Test installers](https://stealthpuppy.com/evergreen/test/)


### PR DESCRIPTION
* Update default user agent #642 
* Fix an issue with `Get-Architecture` returning `AMD64` #663 
* Adds `Get-EvergreenAppFromApi`, `Start-EvergreenLibraryUpdate` aliases. Public functions will be renamed in a future release
* Fix various issues with help URI links for public functions
* Update help XML