### PR TITLE
Apps

### DIFF
--- a/Evergreen/Apps/Get-MozillaFirefox.ps1
+++ b/Evergreen/Apps/Get-MozillaFirefox.ps1
@@ -1,4 +1,4 @@
-Function Get-MozillaFirefox {
+function Get-MozillaFirefox {
     <#
         .SYNOPSIS
             Returns downloads for the latest Mozilla Firefox releases.
@@ -7,6 +7,8 @@ Function Get-MozillaFirefox {
             Site: https://stealthpuppy.com
             Author: Aaron Parker
             Twitter: @stealthpuppy
+
+            # https://wiki.mozilla.org/Release_Management/Product_details
     #>
     [OutputType([System.Management.Automation.PSObject])]
     [CmdletBinding(SupportsShouldProcess = $false)]
@@ -37,11 +39,19 @@ Function Get-MozillaFirefox {
                         ErrorAction   = "SilentlyContinue"
                     }
                     $Url = Resolve-InvokeWebRequest @params
+                    if ($null -ne $Url) {
 
-                    if ($Null -ne $Url) {
+                        # Catch if version is null
+                        if ([System.String]::IsNullOrEmpty($Versions.$channel)) {
+                            $Version = "Unknown"
+                        }
+                        else {
+                            $Version = $Versions.$channel -replace $res.Get.Download.ReplaceText.Version, ""
+                        }
+
                         # Build object and output to the pipeline
                         $PSObject = [PSCustomObject] @{
-                            Version      = $Versions.$channel -replace $res.Get.Download.ReplaceText.Version, ""
+                            Version      = $Version
                             Architecture = Get-Architecture -String $platform
                             Channel      = $channel
                             Language     = $currentLanguage

--- a/Evergreen/Apps/Get-MozillaFirefox.ps1
+++ b/Evergreen/Apps/Get-MozillaFirefox.ps1
@@ -28,13 +28,13 @@ function Get-MozillaFirefox {
 
     # Construct custom object with output details
     foreach ($currentLanguage in $Language) {
-        foreach ($channel in $res.Get.Update.Channels) {
+        foreach ($channel in $res.Get.Update.Channels.GetEnumerator()) {
             foreach ($platform in $res.Get.Download.Platforms) {
 
                 # Select the download file for the selected platform
-                foreach ($installer in $res.Get.Download.Uri[$channel].GetEnumerator()) {
+                foreach ($installer in $res.Get.Download.Uri[$channel.Key].GetEnumerator()) {
                     $params = @{
-                        Uri           = (($res.Get.Download.Uri[$channel][$installer.Key] -replace $res.Get.Download.ReplaceText.Platform, $platform) -replace $res.Get.Download.ReplaceText.Language, $currentLanguage)
+                        Uri           = (($res.Get.Download.Uri[$channel.Key][$installer.Key] -replace $res.Get.Download.ReplaceText.Platform, $platform) -replace $res.Get.Download.ReplaceText.Language, $currentLanguage)
                         WarningAction = "SilentlyContinue"
                         ErrorAction   = "SilentlyContinue"
                     }
@@ -42,18 +42,18 @@ function Get-MozillaFirefox {
                     if ($null -ne $Url) {
 
                         # Catch if version is null
-                        if ([System.String]::IsNullOrEmpty($Versions.$channel)) {
+                        if ([System.String]::IsNullOrEmpty($Versions.$($channel.Key))) {
                             $Version = "Unknown"
                         }
                         else {
-                            $Version = $Versions.$channel -replace $res.Get.Download.ReplaceText.Version, ""
+                            $Version = $Versions.$($channel.Key) -replace $res.Get.Download.ReplaceText.Version, ""
                         }
 
                         # Build object and output to the pipeline
                         $PSObject = [PSCustomObject] @{
                             Version      = $Version
                             Architecture = Get-Architecture -String $platform
-                            Channel      = $channel
+                            Channel      = $channel.Value
                             Language     = $currentLanguage
                             Type         = [System.IO.Path]::GetExtension($Url).Split(".")[-1]
                             Filename     = (Split-Path -Path $Url -Leaf).Replace('%20', ' ')

--- a/Evergreen/Apps/Get-TableauDesktop.ps1
+++ b/Evergreen/Apps/Get-TableauDesktop.ps1
@@ -1,39 +1,41 @@
-Function Get-TableauDesktop {
+function Get-TableauDesktop {
     <#
-        .SYNOPSIS
-            Get the current version and download URL for Tableau Desktop.
-
         .NOTES
             Author: Andrew Cooper
             Twitter: @adotcoop
             based on Get-TelerikFiddlerEverywhere.ps1
     #>
     [OutputType([System.Management.Automation.PSObject])]
-    [CmdletBinding(SupportsShouldProcess = $False)]
+    [CmdletBinding(SupportsShouldProcess = $false)]
     param (
-        [Parameter(Mandatory = $False, Position = 0)]
+        [Parameter(Mandatory = $false, Position = 0)]
         [ValidateNotNull()]
         [System.Management.Automation.PSObject]
         $res = (Get-FunctionResource -AppName ("$($MyInvocation.MyCommand)".Split("-"))[1])
     )
 
     # Get the latest download
-    $Response = Resolve-SystemNetWebRequest -Uri $res.Get.Download.Uri
-
-    If ($Null -ne $Response) {
+    $params = @{
+        Uri     = $res.Get.Download.Uri
+        Headers = $res.Get.Download.Headers
+    }
+    $Response = Resolve-InvokeWebRequest @params
+    if ($null -ne $Response) {
 
         # Extract the version information from the uri
         try {
-            $Version = [RegEx]::Match($Response.ResponseUri.LocalPath, $res.Get.Download.MatchVersion).Captures.Groups[1].Value
+            $Version = [RegEx]::Match($Response, $res.Get.Download.MatchVersion).Captures.Groups[1].Value
         }
         catch {
-            Throw "$($MyInvocation.MyCommand): Failed to extract the version information from the uri."
+            throw "$($MyInvocation.MyCommand): Failed to extract the version information from the uri."
         }
 
         # Construct the output; Return the custom object to the pipeline
         $PSObject = [PSCustomObject] @{
-            Version = $Version.Replace('-', '.')
-            URI     = $Response.ResponseUri.AbsoluteUri
+            Version      = $Version.Replace('-', '.')
+            Architecture = Get-Architecture -String $Response
+            Type         = Get-FileType -File $Response
+            URI          = $Response
         }
         Write-Output -InputObject $PSObject
     }

--- a/Evergreen/Apps/Get-TableauPrep.ps1
+++ b/Evergreen/Apps/Get-TableauPrep.ps1
@@ -1,39 +1,41 @@
-Function Get-TableauPrep {
+function Get-TableauPrep {
     <#
-        .SYNOPSIS
-            Get the current version and download URL for Tableau Prep.
-
         .NOTES
             Author: Andrew Cooper
             Twitter: @adotcoop
             based on Get-TelerikFiddlerEverywhere.ps1
     #>
     [OutputType([System.Management.Automation.PSObject])]
-    [CmdletBinding(SupportsShouldProcess = $False)]
+    [CmdletBinding(SupportsShouldProcess = $false)]
     param (
-        [Parameter(Mandatory = $False, Position = 0)]
+        [Parameter(Mandatory = $false, Position = 0)]
         [ValidateNotNull()]
         [System.Management.Automation.PSObject]
         $res = (Get-FunctionResource -AppName ("$($MyInvocation.MyCommand)".Split("-"))[1])
     )
 
     # Get the latest download
-    $Response = Resolve-SystemNetWebRequest -Uri $res.Get.Download.Uri
-
-    If ($Null -ne $Response) {
+    $params = @{
+        Uri     = $res.Get.Download.Uri
+        Headers = $res.Get.Download.Headers
+    }
+    $Response = Resolve-InvokeWebRequest @params
+    if ($null -ne $Response) {
 
         # Extract the version information from the uri
         try {
-            $Version = [RegEx]::Match($Response.ResponseUri.LocalPath, $res.Get.Download.MatchVersion).Captures.Groups[1].Value
+            $Version = [RegEx]::Match($Response, $res.Get.Download.MatchVersion).Captures.Groups[1].Value
         }
         catch {
-            Throw "$($MyInvocation.MyCommand): Failed to extract the version information from the uri."
+            throw "$($MyInvocation.MyCommand): Failed to extract the version information from the uri."
         }
 
         # Construct the output; Return the custom object to the pipeline
         $PSObject = [PSCustomObject] @{
-            Version = $Version.Replace('-', '.')
-            URI     = $Response.ResponseUri.AbsoluteUri
+            Version      = $Version.Replace('-', '.')
+            Architecture = Get-Architecture -String $Response
+            Type         = Get-FileType -File $Response
+            URI          = $Response
         }
         Write-Output -InputObject $PSObject
     }

--- a/Evergreen/Apps/Get-VSCodium.ps1
+++ b/Evergreen/Apps/Get-VSCodium.ps1
@@ -1,0 +1,25 @@
+Function Get-VSCodium {
+    <#
+        .NOTES
+            Author: Aaron Parker
+            Twitter: @stealthpuppy
+    #>
+    [OutputType([System.Management.Automation.PSObject])]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseSingularNouns", "", Justification="Product name is a plural")]
+    [CmdletBinding(SupportsShouldProcess = $False)]
+    param (
+        [Parameter(Mandatory = $False, Position = 0)]
+        [ValidateNotNull()]
+        [System.Management.Automation.PSObject]
+        $res = (Get-FunctionResource -AppName ("$($MyInvocation.MyCommand)".Split("-"))[1])
+    )
+
+    # Pass the repo releases API URL and return a formatted object
+    $params = @{
+        Uri          = $res.Get.Uri
+        MatchVersion = $res.Get.MatchVersion
+        Filter       = $res.Get.MatchFileTypes
+    }
+    $object = Get-GitHubRepoRelease @params
+    Write-Output -InputObject $object
+}

--- a/Evergreen/Manifests/McNeelRhino.json
+++ b/Evergreen/Manifests/McNeelRhino.json
@@ -1,21 +1,35 @@
 {
-	"Name": "McNeel Rhino",
-	"Source": "https://www.rhino3d.com/",
-	"Get": {
-		"Update": {
-		"7": "https://store.mcneel.com/api/v1/mcneelupdate/78464c2c-9aeb-456e-8c27-865a524f5ca0/release/win64/en-us/stable/",
-		"6": "https://store.mcneel.com/api/v1/mcneelupdate/06bb1079-5a56-47a1-ad6d-0b45183d894b/release/win64/en-us/stable/"
-		}
-	},
-	"Install": {
-		"Setup": "",
-		"Physical": {
-			"Arguments": "",
-			"PostInstall": []
-		},
-		"Virtual": {
-			"Arguments": "",
-			"PostInstall": []
-		}
-	}
+    "Name": "McNeel Rhino",
+    "Source": "https://www.rhino3d.com/",
+    "Get": {
+        "Update": {
+            "Uri": {
+                "6": "https://store.mcneel.com/api/v1/mcneelupdate/06bb1079-5a56-47a1-ad6d-0b45183d894b/release/win64/#language/stable/",
+                "7": "https://store.mcneel.com/api/v1/mcneelupdate/78464c2c-9aeb-456e-8c27-865a524f5ca0/release/win64/#language/stable/",
+				"8": "https://store.mcneel.com/api/v1/mcneelupdate/868c63f5-3760-4a45-8600-5399cc57b47c/release/win64/#language/stable/"
+            },
+			"Languages": [
+				"en-us",
+				"fr-fr",
+				"es-es",
+				"de-de",
+                "it-it",
+                "ru-ru",
+                "cs-cz",
+                "ja-jp",
+                "ko-kr"
+			]
+        }
+    },
+    "Install": {
+        "Setup": "",
+        "Physical": {
+            "Arguments": "",
+            "PostInstall": []
+        },
+        "Virtual": {
+            "Arguments": "",
+            "PostInstall": []
+        }
+    }
 }

--- a/Evergreen/Manifests/MozillaFirefox.json
+++ b/Evergreen/Manifests/MozillaFirefox.json
@@ -7,10 +7,9 @@
             "Channels": [
                 "LATEST_FIREFOX_VERSION",
                 "FIREFOX_ESR",
-                "FIREFOX_ESR_NEXT"
-            ],
-            "Preview": [
-                "FIREFOX_ESR_NEXT"
+                "FIREFOX_ESR_NEXT",
+                "FIREFOX_DEVEDITION",
+                "LATEST_FIREFOX_RELEASED_DEVEL_VERSION"
             ]
         },
         "Download": {
@@ -29,6 +28,16 @@
                     "Exe": "https://download.mozilla.org/?product=firefox-esr-next-latest-ssl&os=#platform&lang=#language",
                     "Msi": "https://download.mozilla.org/?product=firefox-esr-next-msi-latest-ssl&os=#platform&lang=#language",
                     "Msix": "https://download.mozilla.org/?product=firefox-esr-next-msix-latest-ssl&os=#platform&lang=#language"
+                },
+                "FIREFOX_DEVEDITION": {						 
+                    "Exe": "https://download.mozilla.org/?product=firefox-devedition-latest-ssl&os=#platform&lang=#language",
+                    "Msi": "https://download.mozilla.org/?product=firefox-devedition-msi-latest-ssl&os=#platform&lang=#language",
+                    "Msix": "https://download.mozilla.org/?product=firefox-devedition-next-msix-latest-ssl&os=#platform&lang=#language"
+                },
+                "LATEST_FIREFOX_RELEASED_DEVEL_VERSION": {						 
+                    "Exe": "https://download.mozilla.org/?product=firefox-beta-latest-ssl&os=#platform&lang=#language",
+                    "Msi": "https://download.mozilla.org/?product=firefox-beta-msi-latest-ssl&os=#platform&lang=#language",
+                    "Msix": "https://download.mozilla.org/?product=firefox-beta-next-msix-latest-ssl&os=#platform&lang=#language"
                 }
             },
             "Platforms": [

--- a/Evergreen/Manifests/MozillaFirefox.json
+++ b/Evergreen/Manifests/MozillaFirefox.json
@@ -4,13 +4,13 @@
     "Get": {
         "Update": {
             "Uri": "https://product-details.mozilla.org/1.0/firefox_versions.json",
-            "Channels": [
-                "LATEST_FIREFOX_VERSION",
-                "FIREFOX_ESR",
-                "FIREFOX_ESR_NEXT",
-                "FIREFOX_DEVEDITION",
-                "LATEST_FIREFOX_RELEASED_DEVEL_VERSION"
-            ]
+            "Channels": {
+                "LATEST_FIREFOX_VERSION": "Current",
+                "FIREFOX_ESR": "Extended Support",
+                "FIREFOX_ESR_NEXT": "Extended Support Next",
+                "FIREFOX_DEVEDITION": "Developer",
+                "LATEST_FIREFOX_RELEASED_DEVEL_VERSION": "Beta"
+            }
         },
         "Download": {
             "Uri": {

--- a/Evergreen/Manifests/TableauDesktop.json
+++ b/Evergreen/Manifests/TableauDesktop.json
@@ -8,7 +8,26 @@
 		"Download": {
 			"Uri": "https://www.tableau.com/downloads/desktop/pc64",
 			"Property": "ResponseUri.Headers.Location",
-			"MatchVersion": "(\\d+(\\-\\d+){1,3})"
+			"MatchVersion": "(\\d+(\\-\\d+){1,3})",
+			"Headers": {
+                "sec-fetch-dest": "document",
+                "accept-language": "en-AU,en-GB;q=0.9,en;q=0.8,en-US;q=0.7",
+                "sec-fetch-mode": "navigate",
+                "dnt": "1",
+                "method": "GET",
+                "sec-ch-ua-mobile": "?0",
+                "scheme": "https",
+                "sec-ch-ua-platform": "\"macOS\"",
+                "authority": "www.tableau.com",
+                "sec-ch-ua": "\"Chromium\";v=\"124\", \"Microsoft Edge\";v=\"124\", \"Not-A.Brand\";v=\"99\"",
+                "upgrade-insecure-requests": "1",
+                "accept-encoding": "gzip, deflate, br, zstd",
+                "sec-fetch-site": "none",
+                "priority": "u=0, i",
+                "path": "/downloads/desktop/pc64",
+                "accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7",
+                "sec-fetch-user": "?1"
+            }
 		}
 	},
 	"Install": {

--- a/Evergreen/Manifests/TableauPrep.json
+++ b/Evergreen/Manifests/TableauPrep.json
@@ -8,7 +8,26 @@
 		"Download": {
 			"Uri": "https://www.tableau.com/downloads/prep/pc64",
 			"Property": "ResponseUri.Headers.Location",
-			"MatchVersion": "(\\d+(\\-\\d+){1,3})"
+			"MatchVersion": "(\\d+(\\-\\d+){1,3})",
+			"Headers": {
+                "sec-fetch-dest": "document",
+                "accept-language": "en-AU,en-GB;q=0.9,en;q=0.8,en-US;q=0.7",
+                "sec-fetch-mode": "navigate",
+                "dnt": "1",
+                "method": "GET",
+                "sec-ch-ua-mobile": "?0",
+                "scheme": "https",
+                "sec-ch-ua-platform": "\"macOS\"",
+                "authority": "www.tableau.com",
+                "sec-ch-ua": "\"Chromium\";v=\"124\", \"Microsoft Edge\";v=\"124\", \"Not-A.Brand\";v=\"99\"",
+                "upgrade-insecure-requests": "1",
+                "accept-encoding": "gzip, deflate, br, zstd",
+                "sec-fetch-site": "none",
+                "priority": "u=0, i",
+                "path": "/downloads/desktop/pc64",
+                "accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7",
+                "sec-fetch-user": "?1"
+            }
 		}
 	},
 	"Install": {

--- a/Evergreen/Manifests/TableauReader.json
+++ b/Evergreen/Manifests/TableauReader.json
@@ -1,25 +1,44 @@
 {
-	"Name": "Tableau Reader",
-	"Source": "https://www.tableau.com/",
-	"Get": {
-		"Update": {
-			"Uri": ""
-		},
-		"Download": {
-			"Uri": "https://www.tableau.com/downloads/reader/pc64",
-			"Property": "ResponseUri.Headers.Location",
-			"MatchVersion": "(\\d+(\\-\\d+){1,3})"
-		}
-	},
-	"Install": {
-		"Setup": "TableauReader*.exe",
-		"Physical": {
-			"Arguments": "/quiet /norestart",
-			"PostInstall": []
-		},
-		"Virtual": {
-			"Arguments": "/quiet /norestart",
-			"PostInstall": []
-		}
-	}
+    "Name": "Tableau Reader",
+    "Source": "https://www.tableau.com/",
+    "Get": {
+        "Update": {
+            "Uri": ""
+        },
+        "Download": {
+            "Uri": "https://www.tableau.com/downloads/reader/pc64",
+            "Property": "ResponseUri.Headers.Location",
+            "MatchVersion": "(\\d+(\\-\\d+){1,3})",
+            "Headers": {
+                "sec-fetch-dest": "document",
+                "accept-language": "en-AU,en-GB;q=0.9,en;q=0.8,en-US;q=0.7",
+                "sec-fetch-mode": "navigate",
+                "dnt": "1",
+                "method": "GET",
+                "sec-ch-ua-mobile": "?0",
+                "scheme": "https",
+                "sec-ch-ua-platform": "\"macOS\"",
+                "authority": "www.tableau.com",
+                "sec-ch-ua": "\"Chromium\";v=\"124\", \"Microsoft Edge\";v=\"124\", \"Not-A.Brand\";v=\"99\"",
+                "upgrade-insecure-requests": "1",
+                "accept-encoding": "gzip, deflate, br, zstd",
+                "sec-fetch-site": "none",
+                "priority": "u=0, i",
+                "path": "/downloads/desktop/pc64",
+                "accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7",
+                "sec-fetch-user": "?1"
+            }
+        }
+    },
+    "Install": {
+        "Setup": "TableauReader*.exe",
+        "Physical": {
+            "Arguments": "/quiet /norestart",
+            "PostInstall": []
+        },
+        "Virtual": {
+            "Arguments": "/quiet /norestart",
+            "PostInstall": []
+        }
+    }
 }

--- a/Evergreen/Manifests/VSCodium.json
+++ b/Evergreen/Manifests/VSCodium.json
@@ -1,0 +1,23 @@
+{
+	"Name": "VSCodium",
+	"Source": "https://vscodium.com",
+	"Get": {
+		"Uri": "https://api.github.com/repos/VSCodium/vscodium/releases/latest",
+		"MatchVersion": "(\\d+(\\.\\d+){1,4}).*",
+		"MatchFileTypes": "\\.exe$|\\.msi$"
+	},
+	"Install": {
+		"Setup": "",
+		"Preinstall": "",
+		"Physical": {
+			"Arguments": "/quiet /norestart",
+			"PostInstall": [
+			]
+		},
+		"Virtual": {
+			"Arguments": "/quiet /norestart",
+			"PostInstall": [
+			]
+		}
+	}
+}


### PR DESCRIPTION
* Adds `VSCodium`
* Updates `TableauDesktop`, `TableauPrep`, `TableauReader` to add support for Headers required to resolve download #658 
* Updates `McNeelRhino` to fix resolving update URL. Adds v8, and other languages
* Adds additional release support in `MozillaFirefox` #666
* Renames language property values in `MozillaFirefox` #667