### PR TITLE
Adding Docker Compose

### DIFF
--- a/Evergreen/Apps/Get-DockerCompose.ps1
+++ b/Evergreen/Apps/Get-DockerCompose.ps1
@@ -1,0 +1,26 @@
+Function Get-DockerCompose {
+    <#
+        .SYNOPSIS
+            Returns the available Docker Compose versions.
+
+        .NOTES
+            Author: Kirill Trofimov
+    #>
+    [OutputType([System.Management.Automation.PSObject])]
+    [CmdletBinding(SupportsShouldProcess = $False)]
+    param (
+        [Parameter(Mandatory = $False, Position = 0)]
+        [ValidateNotNull()]
+        [System.Management.Automation.PSObject]
+        $res = (Get-FunctionResource -AppName ("$($MyInvocation.MyCommand)".Split("-"))[1])
+    )
+
+    # Pass the repo releases API URL and return a formatted object
+    $params = @{
+        Uri          = $res.Get.Uri
+        MatchVersion = $res.Get.MatchVersion
+        Filter       = $res.Get.MatchFileTypes
+    }
+    $object = Get-GitHubRepoRelease @params
+    Write-Output -InputObject $object
+}

--- a/Evergreen/Manifests/DockerCompose.json
+++ b/Evergreen/Manifests/DockerCompose.json
@@ -1,0 +1,21 @@
+{
+    "Name": "Docker Compose",
+    "Source": "https://github.com/docker/compose",
+    "Get": {
+        "Uri": "https://api.github.com/repos/docker/compose/releases/latest",
+        "MatchVersion": "(\\d+(\\.\\d+){1,4}).*",
+        "MatchFileTypes": "\\.exe$"
+    },
+    "Install": {
+        "Preinstall": "",
+        "Setup": "",
+        "Physical": {
+            "Arguments": "",
+            "PostInstall": []
+        },
+        "Virtual": {
+            "Arguments": "",
+            "PostInstall": []
+        }
+    }
+}


### PR DESCRIPTION
Hello, there is another new app for Evergreen.

URL: https://github.com/docker/compose

Notes: this is portable app, but to be able to track version in deployment script I would like to add it to Evergreen.

```powershell
Get-EvergreenApp -Name "DockerCompose"

Version       : 2.27.1
Platform      : Windows
Architecture  : ARM64
Type          : exe
InstallerType : Default
Date          : 24/05/2024
Size          : 61491200
URI           : https://github.com/docker/compose/releases/download/v2.27.1/docker-compose-windows-aarch64.exe

Version       : 2.27.1
Platform      : Windows
Architecture  : x64
Type          : exe
InstallerType : Default
Date          : 24/05/2024
Size          : 64080384
URI           : https://github.com/docker/compose/releases/download/v2.27.1/docker-compose-windows-x86_64.exe
```