### PR TITLE
DevToys: Using Pre-release

### DIFF
--- a/Evergreen/Manifests/DevToys.json
+++ b/Evergreen/Manifests/DevToys.json
@@ -2,7 +2,7 @@
 	"Name": "DevToys",
 	"Source": "https://devtoys.app/",
 	"Get": {
-		"Uri": "https://api.github.com/repos/DevToys-app/DevToys/releases",
+		"Uri": "https://api.github.com/repos/DevToys-app/DevToys/releases/latest",
 		"MatchVersion": "(\\d+(\\.\\d+){1,4}).*",
 		"MatchFileTypes": "\\.exe$|\\.zip$|\\.msixbundle$"
 	},

--- a/Evergreen/Manifests/DevToys.json
+++ b/Evergreen/Manifests/DevToys.json
@@ -2,20 +2,20 @@
 	"Name": "DevToys",
 	"Source": "https://devtoys.app/",
 	"Get": {
-		"Uri": "https://api.github.com/repos/DevToys-app/DevToys/releases/latest",
+		"Uri": "https://api.github.com/repos/DevToys-app/DevToys/releases",
 		"MatchVersion": "(\\d+(\\.\\d+){1,4}).*",
-		"MatchFileTypes": "\\.exe$|\\.msi$|\\.msixbundle$"
+		"MatchFileTypes": "\\.exe$|\\.zip$|\\.msixbundle$"
 	},
 	"Install": {
-		"Setup": "Brackets*.msi",
+		"Setup": "*.exe",
 		"Preinstall": "",
 		"Physical": {
-			"Arguments": "/quiet /norestart",
+			"Arguments": "/VERYSILENT /NORESTART",
 			"PostInstall": [
 			]
 		},
 		"Virtual": {
-			"Arguments": "/quiet /norestart",
+			"Arguments": "/VERYSILENT /NORESTART",
 			"PostInstall": [
 			]
 		}


### PR DESCRIPTION
Hello, 

Would like to discuss about this update, as from one hand - it's pre-release, but from other hand - it's offering on official website:
* https://devtoys.app/

Current state:
```powershell
 Workspaces  Get-EvergreenApp -Name "DevToys" | Where-Object { $_.Architecture -eq "x64" -and $_.Type -eq "exe" -and $_.Platform -eq "Windows" }

Version       : 2.0.1.0
Platform      : Windows
Architecture  : x64
Type          : exe
InstallerType : Default
Date          : 08/06/2024
Size          : 58292689
URI           : https://github.com/DevToys-app/DevToys/releases/download/v2.0.1.0/devtoys_win_x64.exe
```

Small changes to get the proper link to installer (thanks, that we can avoid *.msixbundle in this app).
If you are not agree, I can create separate package for it - but I need to know, how to properly name it.

Best,
Kirill