### PR TITLE
Apps

### DIFF
--- a/Evergreen/Apps/Get-CitrixWorkspaceApp.ps1
+++ b/Evergreen/Apps/Get-CitrixWorkspaceApp.ps1
@@ -33,13 +33,19 @@
 
         # Walk through each node to output details
         foreach ($Installer in $Installers) {
+
+            # Write a warning if Citrix is throttling updates
+            if ($Installer.Version -eq "0.0.0.0") {
+                Write-Warning -Message "$($MyInvocation.MyCommand): Citrix may be throttling availability of updates for $($Installer.ShortDescription -replace ':', '')."
+            }
+
             $PSObject = [PSCustomObject] @{
                 Version = $Installer.Version
-                Title   = $($Installer.ShortDescription -replace ":", "")
+                Stream  = $Installer.Stream
+                Date    = ConvertTo-DateTime -DateTime $Installer.StartDate -Pattern $res.Get.Update.DatePattern
+                #Title   = $($Installer.ShortDescription -replace ":", "")
                 Size    = $(if ($Installer.Size) { $Installer.Size } else { "Unknown" })
                 Hash    = $Installer.Hash
-                Date    = ConvertTo-DateTime -DateTime $Installer.StartDate -Pattern $res.Get.Update.DatePattern
-                Stream  = $Installer.Stream
                 URI     = "$($res.Get.Download.Uri)$($Installer.DownloadURL)"
             }
             Write-Output -InputObject $PSObject

--- a/Evergreen/Apps/Get-GoogleChrome.ps1
+++ b/Evergreen/Apps/Get-GoogleChrome.ps1
@@ -55,9 +55,9 @@ function Get-GoogleChrome {
         # Output the version and URI object
         $PSObject = [PSCustomObject] @{
             Version      = $Version
+            Channel      = $Channel
             StartDate    = $Date
             Architecture = Get-Architecture -String $res.Get.Download.Uri.$Channel
-            Channel      = $Channel
             Type         = Get-FileType -File $res.Get.Download.Uri.$Channel
             URI          = $res.Get.Download.Uri.$Channel
         }
@@ -67,9 +67,9 @@ function Get-GoogleChrome {
             # Output the version and URI for the bundle download
             $PSObject = [PSCustomObject] @{
                 Version      = $Version
+                Channel      = $Channel
                 StartDate    = $Date
                 Architecture = Get-Architecture -String $res.Get.Download.Bundle
-                Channel      = $Channel
                 Type         = Get-FileType -File $res.Get.Download.Bundle
                 URI          = $res.Get.Download.Bundle
             }
@@ -80,9 +80,9 @@ function Get-GoogleChrome {
             # Output the version and URI object for the 32-bit version
             $PSObject = [PSCustomObject] @{
                 Version      = $Version
+                Channel      = $Channel
                 StartDate    = $Date
                 Architecture = Get-Architecture -String $($res.Get.Download.Uri.$Channel -replace "64", "")
-                Channel      = $Channel
                 Type         = Get-FileType -File $res.Get.Download.Uri.$Channel
                 URI          = $res.Get.Download.Uri.$Channel -replace "64", ""
             }

--- a/Evergreen/Apps/Get-JGraphDrawIO.ps1
+++ b/Evergreen/Apps/Get-JGraphDrawIO.ps1
@@ -1,16 +1,16 @@
-Function Get-diagrams.net {
+function Get-JGraphDrawIO {
     <#
         .SYNOPSIS
-            Returns the latest diagrams.net version number and download.
+            Returns the latest JGraph DrawIO / diagrams.net version number and download.
 
         .NOTES
             Author: Aaron Parker
             Twitter: @stealthpuppy
     #>
     [OutputType([System.Management.Automation.PSObject])]
-    [CmdletBinding(SupportsShouldProcess = $False)]
+    [CmdletBinding(SupportsShouldProcess = $false)]
     param (
-        [Parameter(Mandatory = $False, Position = 0)]
+        [Parameter(Mandatory = $false, Position = 0)]
         [ValidateNotNull()]
         [System.Management.Automation.PSObject]
         $res = (Get-FunctionResource -AppName ("$($MyInvocation.MyCommand)".Split("-"))[1])

--- a/Evergreen/Apps/Get-MicrosoftOneDrive.ps1
+++ b/Evergreen/Apps/Get-MicrosoftOneDrive.ps1
@@ -38,11 +38,11 @@
                 if ([System.Boolean]($node.PSobject.Properties.name -match "amd64binary")) {
                     [PSCustomObject] @{
                         Version      = $node.currentversion
-                        Throttle     = $node.throttle
-                        Architecture = Get-Architecture -String $node.amd64binary.url
                         Ring         = $ring.Name
-                        Type         = Get-FileType -File $node.amd64binary.url
+                        Throttle     = $node.throttle
                         Sha256       = ConvertFrom-Base64String -Base64String $node.amd64binary.sha256hash
+                        Architecture = Get-Architecture -String $node.amd64binary.url
+                        Type         = Get-FileType -File $node.amd64binary.url
                         URI          = $node.amd64binary.url
                     } | Write-Output
                 }
@@ -50,11 +50,11 @@
                 if ([System.Boolean]($node.PSobject.Properties.name -match "arm64binary")) {
                     [PSCustomObject] @{
                         Version      = $node.currentversion
-                        Throttle     = $node.throttle
-                        Architecture = Get-Architecture -String $node.arm64binary.url
                         Ring         = $ring.Name
-                        Type         = Get-FileType -File $node.arm64binary.url
+                        Throttle     = $node.throttle
                         Sha256       = ConvertFrom-Base64String -Base64String $node.arm64binary.sha256hash
+                        Architecture = Get-Architecture -String $node.arm64binary.url
+                        Type         = Get-FileType -File $node.arm64binary.url
                         URI          = $node.arm64binary.url
                     } | Write-Output
                 }
@@ -63,11 +63,11 @@
                     # Construct the output for MSIX; Return the custom object to the pipeline
                     [PSCustomObject] @{
                         Version      = $node.currentversion
-                        Throttle     = $node.throttle
-                        Architecture = Get-Architecture -String $node.msixbinary.url
                         Ring         = $ring.Name
-                        Type         = Get-FileType -File $node.msixbinary.url
+                        Throttle     = $node.throttle
                         Sha256       = if ($node.msixbinary.sha256hash) { ConvertFrom-Base64String -Base64String $node.msixbinary.sha256hash } else { "N/A" }
+                        Architecture = Get-Architecture -String $node.msixbinary.url
+                        Type         = Get-FileType -File $node.msixbinary.url
                         URI          = $node.msixbinary.url
                     } | Write-Output
                 }
@@ -76,11 +76,11 @@
                 if ([System.Boolean]($node.PSobject.Properties.name -match "binary")) {
                     $PSObject = [PSCustomObject] @{
                         Version      = $node.currentversion
-                        Throttle     = $node.throttle
-                        Architecture = Get-Architecture -String $node.binary.url
                         Ring         = $ring.Name
-                        Type         = Get-FileType -File $node.binary.url
+                        Throttle     = $node.throttle
                         Sha256       = ConvertFrom-Base64String -Base64String $node.binary.sha256hash
+                        Architecture = Get-Architecture -String $node.binary.url
+                        Type         = Get-FileType -File $node.binary.url
                         URI          = $node.binary.url
                     }
                     Write-Output -InputObject $PSObject

--- a/Evergreen/Apps/Get-MozillaFirefox.ps1
+++ b/Evergreen/Apps/Get-MozillaFirefox.ps1
@@ -56,9 +56,9 @@ function Get-MozillaFirefox {
                         # Build object and output to the pipeline
                         $PSObject = [PSCustomObject] @{
                             Version      = $Version
-                            Architecture = Get-Architecture -String $platform
                             Channel      = $channel.Value
                             Language     = $currentLanguage
+                            Architecture = Get-Architecture -String $platform
                             Type         = Get-FileType -File $Url
                             Filename     = (Split-Path -Path $Url -Leaf).Replace('%20', ' ')
                             URI          = $Url

--- a/Evergreen/Apps/Get-MozillaThunderbird.ps1
+++ b/Evergreen/Apps/Get-MozillaThunderbird.ps1
@@ -56,9 +56,9 @@ function Get-MozillaThunderbird {
                         # Build object and output to the pipeline
                         $PSObject = [PSCustomObject] @{
                             Version      = $Version
-                            Architecture = Get-Architecture -String $platform
                             Channel      = $channel.Value
                             Language     = $currentLanguage
+                            Architecture = Get-Architecture -String $platform
                             Type         = Get-FileType -File $Url
                             Filename     = (Split-Path -Path $Url -Leaf).Replace('%20', ' ')
                             URI          = $Url
@@ -75,9 +75,9 @@ function Get-MozillaThunderbird {
 
                 $PSObject = [PSCustomObject] @{
                     Version      = $Version
-                    Architecture = "x64"
                     Channel      = $channel.Value
                     Language     = "Multi"
+                    Architecture = "x64"
                     Type         = Get-FileType -File $Url
                     Filename     = (Split-Path -Path $Url -Leaf).Replace('%20', ' ')
                     URI          = $Url

--- a/Evergreen/Apps/Get-VideoLanVlcPlayer.ps1
+++ b/Evergreen/Apps/Get-VideoLanVlcPlayer.ps1
@@ -1,4 +1,4 @@
-﻿Function Get-VideoLanVlcPlayer {
+﻿function Get-VideoLanVlcPlayer {
     <#
         .SYNOPSIS
             Get the current version and download URL for VideoLAN VLC Media Player.
@@ -9,42 +9,51 @@
             Twitter: @stealthpuppy
     #>
     [OutputType([System.Management.Automation.PSObject])]
-    [CmdletBinding(SupportsShouldProcess = $False)]
+    [CmdletBinding(SupportsShouldProcess = $false)]
     param (
-        [Parameter(Mandatory = $False, Position = 0)]
+        [Parameter(Mandatory = $false, Position = 0)]
         [ValidateNotNull()]
         [System.Management.Automation.PSObject]
         $res = (Get-FunctionResource -AppName ("$($MyInvocation.MyCommand)".Split("-"))[1])
     )
 
-    #region Get current version for Windows
-    ForEach ($platform in $res.Get.Update.Uri.Windows.GetEnumerator()) {
-        $params = @{
-            Uri         = $res.Get.Update.Uri.Windows[$platform.Key]
-            ContentType = "application/octet-stream"
-        }
-        $Content = Invoke-EvergreenRestMethod @params
-
-        If ($Null -ne $Content) {
-            # Follow the download link which will return a 301
-            $params = @{
-                Uri       = ($Content -split "\n")[$res.Get.Download.UrlLine]
-                UserAgent = $res.Get.Update.UserAgent
-            }
-            $redirectUrl = Resolve-InvokeWebRequest @params
-
-            # Construct the output; Return the custom object to the pipeline
-            ForEach ($extension in $res.Get.Download.Extensions.Windows) {
-                $PSObject = [PSCustomObject] @{
-                    Version      = ($Content -split "\n")[$res.Get.Download.VersionLine]
-                    Platform     = "Windows"
-                    Architecture = $platform.Name
-                    Type         = $extension
-                    URI          = $redirectUrl -replace ".exe$", (".$extension").ToLower()
-                }
-                Write-Output -InputObject $PSObject
-            }
-        }
+    begin {
+        Write-Warning -Message "$($MyInvocation.MyCommand): This function returns the version returned by 'Help > Check for Updates' in VLC Player. https://get.videolan.org/ may show a later available version for download."
     }
-    #endregion
+    process {
+        #region Get current version for Windows
+        foreach ($Url in $res.Get.Update.Uri) {
+            $params = @{
+                Uri         = $Url
+                UserAgent   = $res.Get.Update.UserAgent
+                ContentType = $res.Get.Update.ContentType
+            }
+            $Content = Invoke-EvergreenRestMethod @params
+
+            if ($Null -ne $Content) {
+                # Follow the download link which will return a 301
+                $params = @{
+                    Uri       = ($Content -split "\n")[$res.Get.Download.UrlLine]
+                    UserAgent = $res.Get.Update.UserAgent
+                }
+                $redirectUrl = Resolve-InvokeWebRequest @params
+
+                # Construct the output; Return the custom object to the pipeline
+                foreach ($extension in $res.Get.Download.Extensions.Windows) {
+
+                    $Version = ($Content -split "\n")[$res.Get.Download.VersionLine]
+                    $Uri = $redirectUrl -replace ".exe$", (".$extension").ToLower()
+
+                    $PSObject = [PSCustomObject] @{
+                        Version      = $Version
+                        Architecture = Get-Architecture -String $Uri
+                        Type         = Get-FileType -File $Uri
+                        URI          = $Uri
+                    }
+                    Write-Output -InputObject $PSObject
+                }
+            }
+        }
+        #endregion
+    }
 }

--- a/Evergreen/Manifests/JGraphDrawIO.json
+++ b/Evergreen/Manifests/JGraphDrawIO.json
@@ -1,6 +1,6 @@
 {
-	"Name": "diagrams.net",
-	"Source": "https://www.diagrams.net/",
+	"Name": "JGraph draw.io (diagrams.net)",
+	"Source": "https://www.drawio.com",
 	"Get": {
 		"Uri": "https://api.github.com/repos/jgraph/drawio-desktop/releases/latest",
 		"MatchVersion": "(\\d+(\\.\\d+){1,4}).*",

--- a/Evergreen/Manifests/MicrosoftVisualStudio.json
+++ b/Evergreen/Manifests/MicrosoftVisualStudio.json
@@ -8,15 +8,15 @@
 		}
 	},
 	"Install": {
-		"Setup": "AppName.*.exe",
+		"Setup": "vs_Setup.exe",
 		"Physical": {
-			"Arguments": "--channelid \"VisualStudio.17.Release\" --productid \"Microsoft.VisualStudio.Product.Community\"",
+			"Arguments": "--quiet --wait --norestart --force --channelid \"VisualStudio.17.Release\" --productid \"Microsoft.VisualStudio.Product.Community\"",
 			"PostInstall": [
 
 			]
 		},
 		"Virtual": {
-			"Arguments": "--channelid \"VisualStudio.17.Release\" --productid \"Microsoft.VisualStudio.Product.Community\"",
+			"Arguments": "--quiet --wait --norestart --force --channelid \"VisualStudio.17.Release\" --productid \"Microsoft.VisualStudio.Product.Community\"",
 			"PostInstall": [
 
 			]

--- a/Evergreen/Manifests/ScooterBeyondCompare.json
+++ b/Evergreen/Manifests/ScooterBeyondCompare.json
@@ -2,18 +2,25 @@
     "Name": "Scooter Beyond Compare",
     "Source": "https://scootersoftware.com/",
     "Get": {
-        "Uri": {
-            "en": "https://www.scootersoftware.com/checkupdates.php?product=bc4&minor=3&maint=2&auth=30.15&build=24472&edition=prodebug&cpuarch=x86_64&platform=win32&lang=silent"
+        "Update": {
+            "Uri": "https://www.scootersoftware.com/checkupdates.php?product=bc4&minor=3&maint=2&auth=30.15&build=24472&edition=prodebug&cpuarch=x86_64&platform=win32&lang=silent",
+            "UserAgent": "BeyondCompare/4.3 (Windows NT 10.0; Win64; x64)",
+            "XmlNode": "//Update",
+            "MatchVersion": "(\\d+(\\.\\d+)(\\.\\d+))",
+            "ReplaceText": " build ",
+            "Languages": {
+                "en": "English",
+                "de": "German",
+                "fr": "French",
+                "jp": "Japanese",
+                "zh": "Chinese (Simplified)"
+            }
         },
-        "UserAgent": "BeyondCompare/4.3 (Windows NT 10.0; Win64; x64)",
-        "XmlNode": "//Update",
-        "MatchVersion": "(\\d+(\\.\\d+)(\\.\\d+))",
-        "Languages": {
-            "en": "English",
-            "de": "German",
-            "fr": "French",
-            "jp": "Japanese",
-            "zh": "Chinese (Simplified)"
+        "Download": {
+            "Uri": [
+                "https://www.scootersoftware.com/files/BCompare-#version_x64.msi",
+                "https://www.scootersoftware.com/files/BCompare-#version_x86.msi"
+            ]
         }
     },
     "Install": {

--- a/Evergreen/Manifests/VercelHyper.json
+++ b/Evergreen/Manifests/VercelHyper.json
@@ -1,6 +1,6 @@
 {
 	"Name": "Vercel Hyper",
-	"Source": "https://hyper.js/",
+	"Source": "https://hyper.is/",
 	"Get": {
 		"Uri": "https://api.github.com/repos/vercel/hyper/releases/latest",
 		"MatchVersion": "(\\d+(\\.\\d+){1,4}).*",

--- a/Evergreen/Manifests/VideoLanVlcPlayer.json
+++ b/Evergreen/Manifests/VideoLanVlcPlayer.json
@@ -3,23 +3,21 @@
     "Source": "https://www.videolan.org/vlc/",
     "Get": {
         "Update": {
-            "Uri": {
-                "Windows": {
-                    "x64": "https://update.videolan.org/vlc/status-win-x64",
-                    "x86": "https://update.videolan.org/vlc/status-win-x86"
-                }
-            },
+            "Uri": [
+                "https://update.videolan.org/vlc/status-win-x64",
+                "https://update.videolan.org/vlc/status-win-x86"
+            ],
             "ContentType": "application/octet-stream",
             "UserAgent": "VLC/3.0.16 LibVLC/3.0.16"
         },
         "Download": {
-			"VersionLine": 0,
-			"UrlLine": 1,
+            "VersionLine": 0,
+            "UrlLine": 1,
             "Extensions": {
                 "Windows": [
-                    "EXE",
-                    "MSI",
-                    "ZIP"
+                    "exe",
+                    "msi",
+                    "zip"
                 ]
             }
         }

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,15 @@
 # Change log
 
+## VERSION
+
+* Updates `ScooterBeyondCompare` with additional languages
+* Updates `VideoLanVlcPlayer` [#704](https://github.com/aaronparker/evergreen/issues/704) [#158](https://github.com/aaronparker/evergreen/issues/158), `CitrixWorkspaceApp` [#578](https://github.com/aaronparker/evergreen/issues/578) [#298](https://github.com/aaronparker/evergreen/issues/298) to output warnings for known issues
+* Updates `GoogleChrome`, `MicrosoftOneDrive`, `MozillaFirefox`, `MozillaThunderbird` to reorder output properties
+
+BREAKING CHANGES
+
+* Renames `diagrams.net` to `JGraphDrawIO` [#714](https://github.com/aaronparker/evergreen/issues/714)
+
 ## 2407.1202
 
 * Adds `AmazonCorretto8`, `AmazonCorretto11`, `AmazonCorretto16`, `AmazonCorretto17`, `AmazonCorretto20`, `AmazonCorretto21`, `AmazonCorretto22` [#711](https://github.com/aaronparker/evergreen/issues/711)


### PR DESCRIPTION
* Updates `ScooterBeyondCompare` with additional languages
* Updates `VideoLanVlcPlayer` [#704](https://github.com/aaronparker/evergreen/issues/704) [#158](https://github.com/aaronparker/evergreen/issues/158), `CitrixWorkspaceApp` [#578](https://github.com/aaronparker/evergreen/issues/578) [#298](https://github.com/aaronparker/evergreen/issues/298) to output warnings for known issues
* Updates `GoogleChrome`, `MicrosoftOneDrive`, `MozillaFirefox`, `MozillaThunderbird` to reorder output properties

BREAKING CHANGES

* Renames `diagrams.net` to `JGraphDrawIO` [#714](https://github.com/aaronparker/evergreen/issues/714)