### PR TITLE
OBS Studio: Adding alt version using GitHub Releases

### DIFF
--- a/Evergreen/Apps/Get-OBSStudioAlt.ps1
+++ b/Evergreen/Apps/Get-OBSStudioAlt.ps1
@@ -1,0 +1,27 @@
+﻿Function Get-OBSStudioAlt {
+    <#
+        .SYNOPSIS
+            Get the current version and download URI for OBS Studio.
+
+        .NOTES
+            Author: Kirill Trofimov
+    #>
+    [OutputType([System.Management.Automation.PSObject])]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseSingularNouns", "", Justification="Product name is a plural")]
+    [CmdletBinding(SupportsShouldProcess = $False)]
+    param (
+        [Parameter(Mandatory = $False, Position = 0)]
+        [ValidateNotNull()]
+        [System.Management.Automation.PSObject]
+        $res = (Get-FunctionResource -AppName ("$($MyInvocation.MyCommand)".Split("-"))[1])
+    )
+
+    # Pass the repo releases API URL and return a formatted object
+    $params = @{
+        Uri          = $res.Get.Uri
+        MatchVersion = $res.Get.MatchVersion
+        Filter       = $res.Get.MatchFileTypes
+    }
+    $object = Get-GitHubRepoRelease @params
+    Write-Output -InputObject $object
+}

--- a/Evergreen/Manifests/OBSStudioAlt.json
+++ b/Evergreen/Manifests/OBSStudioAlt.json
@@ -1,0 +1,23 @@
+﻿{
+	"Name": "OBS Studio Alt",
+	"Source": "https://obsproject.com/",
+	"Get": {
+		"Uri": "https://api.github.com/repos/obsproject/obs-studio/releases/latest",
+		"MatchVersion": "(\\d+(\\.\\d+){1,4}).*",
+		"MatchFileTypes": "\\.exe$|\\.zip$"
+	},
+	"Install": {
+		"Setup": "*.exe",
+		"Preinstall": "",
+		"Physical": {
+			"Arguments": "/S",
+			"PostInstall": [
+			]
+		},
+		"Virtual": {
+			"Arguments": "/S",
+			"PostInstall": [
+			]
+		}
+	}
+}


### PR DESCRIPTION
As proposed in #719, created alt version of OBS Studio:

```
> Get-EvergreenApp -Name "OBSStudioAlt"

Version       : 30.2.2
Date          : 23/07/2024
Size          : 139815840
Architecture  : x86
InstallerType : Default
Type          : exe
URI           : https://github.com/obsproject/obs-studio/releases/download/30.2.2/OBS-Studio-30.2.2-Windows-Installer.exe

Version       : 30.2.2
Date          : 23/07/2024
Size          : 51686890
Architecture  : x86
InstallerType : Default
Type          : zip
URI           : https://github.com/obsproject/obs-studio/releases/download/30.2.2/OBS-Studio-30.2.2-Windows-PDBs.zip

Version       : 30.2.2
Date          : 23/07/2024
Size          : 158512570
Architecture  : x86
InstallerType : Default
Type          : zip
URI           : https://github.com/obsproject/obs-studio/releases/download/30.2.2/OBS-Studio-30.2.2-Windows.zip
```