### PR TITLE
Microsoft Terminal: extend MatchFileTypes

### DIFF
--- a/Evergreen/Manifests/MicrosoftTerminal.json
+++ b/Evergreen/Manifests/MicrosoftTerminal.json
@@ -4,7 +4,7 @@
 	"Get": {
 		"Uri": "https://api.github.com/repos/microsoft/terminal/releases/latest",
 		"MatchVersion": "(\\d+(\\.\\d+){1,4}).*",
-		"MatchFileTypes": "\\.msixbundle$"
+		"MatchFileTypes": "\\.exe$|\\.msi$|\\.msixbundle$|\\.zip$"
 	},
 	"Install": {
 		"Setup": "",


### PR DESCRIPTION
To follow current and possible feature extensions for installer decided to extend MatchFileTypes:

Reference link: https://github.com/microsoft/terminal/releases
