### PR TITLE
Update OBSStudio.json to match with new download URL

### DIFF
--- a/Evergreen/Manifests/OBSStudio.json
+++ b/Evergreen/Manifests/OBSStudio.json
@@ -13,7 +13,7 @@
         },
         "Download": {
             "Uri": "https://cdn-fastly.obsproject.com/downloads/#FileName",
-            "FileName": "OBS-Studio-#Version-Full-Installer-#Architecture.exe",
+            "FileName": "OBS-Studio-#Version-Windows-Installer.exe",
             "Architectures": [
                 "x64"
             ],


### PR DESCRIPTION
Update OBSStudio.json to match with new download URL https://cdn-fastly.obsproject.com/downloads/OBS-Studio-30.2.3-Windows-Installer.exe. The current old URL is https://cdn-fastly.obsproject.com/downloads/OBS-Studio-30.2.3-Full-Installer-x64.exe which is not valid now.