### PR TITLE
Fix: Overwrite user agent to get mysql apps via azure automation

### DIFF
--- a/Evergreen/Apps/Get-mySQLConnectorNET.ps1
+++ b/Evergreen/Apps/Get-mySQLConnectorNET.ps1
@@ -31,7 +31,8 @@ function Get-mySQLConnectorNET {
             # The version ist major.minor.patch, while the tag can have also have major.minor.patch.build
             $Uri = $res.Get.Download.Uri[$Architecture.Key] -replace $res.Get.Download.ReplaceVersionShort, (($Version -split '\.')[0, 1] -join '.') -replace $res.Get.Download.ReplaceVersion, (($Version -split '\.')[0..2] -join '.')
 
-            $CdnUri = (Invoke-WebRequest $Uri -MaximumRedirection 0 -SkipHttpErrorCheck -ErrorAction:SilentlyContinue).Headers.Location[0]
+            # The website/CDN checks the user agent, which means that the call from e.g. Azure Automation is only possible by overwriting it
+            $CdnUri = (Invoke-WebRequest $Uri -MaximumRedirection 0 -UserAgent "Curl/8" -SkipHttpErrorCheck -ErrorAction:SilentlyContinue).Headers.Location[0]
 
             $PSObject = [PSCustomObject] @{
                 Version      = $Version

--- a/Evergreen/Apps/Get-mySQLConnectorODBC.ps1
+++ b/Evergreen/Apps/Get-mySQLConnectorODBC.ps1
@@ -30,7 +30,8 @@ function Get-mySQLConnectorODBC {
             # The version ist major.minor.patch, while the tag can have also have major.minor.patch.build
             $Uri = $res.Get.Download.Uri[$Architecture.Key] -replace $res.Get.Download.ReplaceVersion, (($Version -split '\.')[0..2] -join '.')
 
-            $CdnUri = (Invoke-WebRequest $Uri -MaximumRedirection 0 -SkipHttpErrorCheck -ErrorAction:SilentlyContinue).Headers.Location[0]
+            # The website/CDN checks the user agent, which means that the call from e.g. Azure Automation is only possible by overwriting it
+            $CdnUri = (Invoke-WebRequest $Uri -MaximumRedirection 0 -UserAgent "Curl/8" -SkipHttpErrorCheck -ErrorAction:SilentlyContinue).Headers.Location[0]
 
             $PSObject = [PSCustomObject] @{
                 Version      = $Version

--- a/Evergreen/Apps/Get-mySQLWorkbench.ps1
+++ b/Evergreen/Apps/Get-mySQLWorkbench.ps1
@@ -30,7 +30,8 @@ function Get-mySQLWorkbench {
             # The version ist major.minor.patch, while the tag can have also have major.minor.patch.build
             $Uri = $res.Get.Download.Uri[$Architecture.Key] -replace $res.Get.Download.ReplaceVersion, (($Version -split '\.')[0..2] -join '.')
 
-            $CdnUri = (Invoke-WebRequest $Uri -MaximumRedirection 0 -SkipHttpErrorCheck -ErrorAction:SilentlyContinue).Headers.Location[0]
+            # The website/CDN checks the user agent, which means that the call from e.g. Azure Automation is only possible by overwriting it
+            $CdnUri = (Invoke-WebRequest $Uri -MaximumRedirection 0 -UserAgent "Curl/8" -SkipHttpErrorCheck -ErrorAction:SilentlyContinue).Headers.Location[0]
 
             $PSObject = [PSCustomObject] @{
                 Version      = $Version


### PR DESCRIPTION
It looks like the website/CDN is checking the user agent... from my client with windows + powershell 7 i always get http code 302, but from a runbook in azure automation it will return 403. 

Overwriting the user agent to something like `curl/x` oder `Mozilla\x (system info...)` will fix this...