### PR TITLE
VisualCppRedistAIO: Adding exe installers, fix Setup pattern

### DIFF
--- a/Evergreen/Manifests/VisualCppRedistAIO.json
+++ b/Evergreen/Manifests/VisualCppRedistAIO.json
@@ -4,10 +4,10 @@
 	"Get": {
 		"Uri": "https://api.github.com/repos/abbodi1406/vcredist/releases/latest",
 		"MatchVersion": "(\\d+(\\.\\d+){1,4})",
-		"MatchFileTypes": "\\.zip$"
+		"MatchFileTypes": "\\.zip$|\\.exe$"
 	},
 	"Install": {
-		"Setup": "VisualCppRedist_AIO_x86_x64_*.zip",
+		"Setup": "VisualCppRedist_AIO_*.exe",
 		"Preinstall": "",
 		"Physical": {
 			"Arguments": "/ai58X239",


### PR DESCRIPTION
Hello, fixed small thing - before it shows only zip files, but author start pushing exe installers a while ago:
Before:
```
~ ❯ Get-EvergreenApp -Name "VisualCppRedistAIO"

Version       : 0.85.0
Date          : 06/11/2024
Size          : 29001418
Architecture  : x64
InstallerType : Default
Type          : zip
URI           : https://github.com/abbodi1406/vcredist/releases/download/v0.85.0/VisualCppRedist_AIO_x86_x64_85.zip
```

After:
```
~ ❯ Get-EvergreenApp -Name "VisualCppRedistAIO"

Version       : 0.85.0
Date          : 06/11/2024
Size          : 17299035
Architecture  : x86
InstallerType : Default
Type          : exe
URI           : https://github.com/abbodi1406/vcredist/releases/download/v0.85.0/VisualCppRedist_AIO_x86only.exe

Version       : 0.85.0
Date          : 06/11/2024
Size          : 29001222
Architecture  : x64
InstallerType : Default
Type          : exe
URI           : https://github.com/abbodi1406/vcredist/releases/download/v0.85.0/VisualCppRedist_AIO_x86_x64.exe

Version       : 0.85.0
Date          : 06/11/2024
Size          : 29001418
Architecture  : x64
InstallerType : Default
Type          : zip
URI           : https://github.com/abbodi1406/vcredist/releases/download/v0.85.0/VisualCppRedist_AIO_x86_x64_85.zip
```