### PR TITLE
fix: LehrerOffice API changed and makes requests fail

### DIFF
--- a/Evergreen/Apps/Get-LehrerOffice.ps1
+++ b/Evergreen/Apps/Get-LehrerOffice.ps1
@@ -18,10 +18,13 @@ Function Get-LehrerOffice {
     }
     $Content = Invoke-EvergreenWebRequest @webrequest
 
+    $versions = $Content | Select-String -Pattern $res.Get.Update.MatchVersion
+    $newestVersion = $versions.Matches.Item(0).Groups.Item(1).Value
+
     # Construct the output; Return the custom object to the pipeline
     If ($Null -ne $Content) {
         $PSObject = [PSCustomObject] @{
-            Version = $Content
+            Version = $newestVersion
             Type    = 'Exe'
             URI     = $res.Get.Download.Uri
         }

--- a/Evergreen/Manifests/LehrerOffice.json
+++ b/Evergreen/Manifests/LehrerOffice.json
@@ -3,7 +3,8 @@
   "Source": "https://lehreroffice.net/",
   "Get": {
     "Update": {
-      "Uri": "https://www.lehreroffice.ch/services/update/getcurrentversion.php?app=Desktop"
+      "Uri": "https://www.cmi-bildung.ch/lo/dateien/easy/lo_version.txt",
+      "MatchVersion": "\\n\\s(\\d{4}([.]\\d){1,2})\\s"
     },
     "Download": {
       "Uri": "https://cmi-bildung.ch/lo/dateien/easy/lo_desktop_windows.exe"


### PR DESCRIPTION
The vendors API fails. According to the error message the API is just
a PHP script that retrieves the version number from the changelog.

The fix reimplements this functionality in PowerShell to work around
the vendors failing PHP script.
