### PR TITLE
Swap mySQLConnectorNET and mySQLConnectorODBC URI's

### DIFF
--- a/Evergreen/Manifests/mySQLConnectorNET.json
+++ b/Evergreen/Manifests/mySQLConnectorNET.json
@@ -7,11 +7,11 @@
       },
       "Download": {
         "Uri": {
-          "x64": "https://dev.mysql.com/get/Downloads/Connector-ODBC/#versionshort/mysql-connector-odbc-#version-winx64.msi"
+          "x64": "https://dev.mysql.com/get/Downloads/Connector-Net/mysql-connector-net-#version.msi"
         },
-        "ReplaceVersion": "#version",
-        "ReplaceVersionShort": "#versionshort"
+        "ReplaceVersion": "#version"
       }
+
     },
     "Install": {
       "Setup": "",

--- a/Evergreen/Manifests/mySQLConnectorODBC.json
+++ b/Evergreen/Manifests/mySQLConnectorODBC.json
@@ -7,9 +7,10 @@
 		},
 		"Download": {
 			"Uri": {
-				"x64": "https://dev.mysql.com/get/Downloads/Connector-Net/mysql-connector-net-#version.msi"
+				"x64": "https://dev.mysql.com/get/Downloads/Connector-ODBC/#versionshort/mysql-connector-odbc-#version-winx64.msi"
 			},
-			"ReplaceVersion": "#version"
+			"ReplaceVersion": "#version",
+			"ReplaceVersionShort": "#versionshort"
 		}
 	},
 	"Install": {


### PR DESCRIPTION
The mySQLConnectorNET and mySQLConnectorODBC URI's were for each others software. I've swapped the `Download` node of each manifest file and confirmed it works in PowerShell.