### PR TITLE
Microsoft Edge functions

### DIFF
--- a/Evergreen/Apps/Get-MicrosoftEdge.ps1
+++ b/Evergreen/Apps/Get-MicrosoftEdge.ps1
@@ -28,8 +28,9 @@ Function Get-MicrosoftEdge {
                     foreach ($Artifact in $Release.Artifacts) {
                         [PSCustomObject]@{
                             Version                 = $Release.ProductVersion
-                            Channel                 = $Item.Product
                             Date                    = $Release.PublishedTime
+                            Channel                 = $Item.Product
+                            Release                 = "Enterprise"
                             Expiry                  = $Release.ExpectedExpiryDate
                             $Artifact.HashAlgorithm = $Artifact.Hash
                             Size                    = $([Math]::Round($Artifact.SizeInBytes / 1MB, 2))

--- a/Evergreen/Apps/Get-MicrosoftEdgeDriver.ps1
+++ b/Evergreen/Apps/Get-MicrosoftEdgeDriver.ps1
@@ -5,12 +5,11 @@ Function Get-MicrosoftEdgeDriver {
 
         .NOTES
             Author: Aaron Parker
-            Twitter: @stealthpuppy
     #>
     [OutputType([System.Management.Automation.PSObject])]
-    [CmdletBinding(SupportsShouldProcess = $False)]
+    [CmdletBinding(SupportsShouldProcess = $false)]
     param (
-        [Parameter(Mandatory = $False, Position = 0)]
+        [Parameter(Mandatory = $false, Position = 0)]
         [ValidateNotNull()]
         [System.Management.Automation.PSObject]
         $res = (Get-FunctionResource -AppName ("$($MyInvocation.MyCommand)".Split("-"))[1])
@@ -20,7 +19,7 @@ Function Get-MicrosoftEdgeDriver {
     $updateFeed = Invoke-EvergreenRestMethod -Uri $res.Get.Update.Uri
 
     # Read the JSON and build an array of platform, channel, architecture, version
-    if ($Null -ne $updateFeed) {
+    if ($null -ne $updateFeed) {
         foreach ($platform in $res.Get.Update.Platforms) {
 
             # For each product (Stable, Beta etc.)

--- a/Evergreen/Apps/Get-MicrosoftEdgeForBusiness.ps1
+++ b/Evergreen/Apps/Get-MicrosoftEdgeForBusiness.ps1
@@ -1,4 +1,4 @@
-Function Get-MicrosoftEdge {
+Function Get-MicrosoftEdgeForBusiness {
     <#
         .SYNOPSIS
             Returns the available Microsoft Edge versions and channels by querying the official Microsoft version JSON.

--- a/Evergreen/Apps/Get-MicrosoftEdgeForBusiness.ps1
+++ b/Evergreen/Apps/Get-MicrosoftEdgeForBusiness.ps1
@@ -28,8 +28,8 @@ Function Get-MicrosoftEdgeForBusiness {
                     foreach ($Artifact in $Release.Artifacts) {
                         [PSCustomObject]@{
                             Version                 = $Release.ProductVersion
-                            Channel                 = $Item.Product
                             Date                    = $Release.PublishedTime
+                            Channel                 = $Item.Product
                             Expiry                  = $Release.ExpectedExpiryDate
                             $Artifact.HashAlgorithm = $Artifact.Hash
                             Size                    = $([Math]::Round($Artifact.SizeInBytes / 1MB, 2))

--- a/Evergreen/Apps/Get-MicrosoftEdgeWebView2Runtime.ps1
+++ b/Evergreen/Apps/Get-MicrosoftEdgeWebView2Runtime.ps1
@@ -5,7 +5,6 @@ Function Get-MicrosoftEdgeWebView2Runtime {
 
         .NOTES
             Author: Aaron Parker
-            Twitter: @stealthpuppy
     #>
     [OutputType([System.Management.Automation.PSObject])]
     [CmdletBinding(SupportsShouldProcess = $False)]
@@ -16,44 +15,38 @@ Function Get-MicrosoftEdgeWebView2Runtime {
         $res = (Get-FunctionResource -AppName ("$($MyInvocation.MyCommand)".Split("-"))[1])
     )
 
-
     # Read the JSON and convert to a PowerShell object. Return the current release version of Edge
-    $updateFeed = Invoke-EvergreenRestMethod -Uri $res.Get.Update.Uri
+    $Feed = Invoke-EvergreenRestMethod -Uri $res.Get.Update.Uri
 
     # Read the JSON and build an array of platform, channel, architecture, version
-    if ($Null -ne $updateFeed) {
-        foreach ($platform in $res.Get.Update.Platforms) {
+    if ($null -ne $Feed) {
+        foreach ($Channel in $res.Get.Update.Channels) {
+            Write-Verbose -Message "$($MyInvocation.MyCommand): Processing channel '$Channel'."
+            $Filtered = $Feed | Where-Object { $_.Product -eq $Channel }
+            foreach ($Platform in $res.Get.Update.Platforms) {
+                Write-Verbose -Message "$($MyInvocation.MyCommand): Processing platform '$Platform'."
+                $PlatformReleases = $Filtered.Releases | Where-Object { $_.Platform -eq "Windows" }
 
-            # For each product (Stable, Beta etc.)
-            foreach ($channel in $res.Get.Update.Channels) {
-                foreach ($architecture in $res.Get.Update.Architectures) {
+                # Sort for the latest release
+                $LatestVersion = $PlatformReleases | Select-Object -ExpandProperty "ProductVersion" | `
+                    Sort-Object -Property @{ Expression = { [System.Version]$_ }; Descending = $true } | `
+                    Select-Object -First 1
+                Write-Verbose -Message "$($MyInvocation.MyCommand): Latest version for $Channel on $Platform is $LatestVersion."
 
-                    # Sort for the latest release
-                    $latestRelease = $updateFeed | Where-Object { $_.Product -eq $channel } | `
-                        Select-Object -ExpandProperty "Releases" | `
-                        Where-Object { $_.Platform -eq $platform -and $_.Architecture -eq $architecture } | `
-                        Sort-Object -Property @{ Expression = { [System.Version]$_.ProductVersion }; Descending = $true } | `
-                        Select-Object -First 1
+                # Create the output object/s
+                foreach ($Release in ($PlatformReleases | Where-Object { $_.ProductVersion -eq $LatestVersion })) {
 
-                    # Create the output object/s
-                    ForEach ($release in $latestRelease) {
-                        If ($release.Artifacts.Count -gt 0) {
-
-                            # Output object to the pipeline
-                            $PSObject = [PSCustomObject] @{
-                                Version      = $release.ProductVersion
-                                Channel      = $channel
-                                Architecture = $architecture
-                                URI          = $(Resolve-SystemNetWebRequest -Uri $res.Get.Download.Uri[$architecture]).ResponseUri.AbsoluteUri
-                            }
-                            Write-Output -InputObject $PSObject
-                        }
+                    # Output object to the pipeline
+                    $Url = $(Resolve-SystemNetWebRequest -Uri $res.Get.Download.Uri[$Release.Architecture]).ResponseUri.AbsoluteUri
+                    $PSObject = [PSCustomObject] @{
+                        Version      = $Release.ProductVersion
+                        Channel      = $Channel
+                        Architecture = $Release.Architecture
+                        URI          = $Url
                     }
+                    Write-Output -InputObject $PSObject
                 }
             }
         }
-    }
-    else {
-        Write-Error -Message "$($MyInvocation.MyCommand): Failed to return content from: $($res.Get.Update.Uri)."
     }
 }

--- a/Evergreen/Manifests/MicrosoftEdgeForBusiness.json
+++ b/Evergreen/Manifests/MicrosoftEdgeForBusiness.json
@@ -1,9 +1,9 @@
 {
-    "Name": "Microsoft Edge",
-    "Source": "https://www.microsoft.com/edge",
+    "Name": "Microsoft Edge for Business",
+    "Source": "https://www.microsoft.com/edge/business/download",
     "Get": {
         "Update": {
-            "Uri": "https://edgeupdates.microsoft.com/api/products",
+            "Uri": "https://edgeupdates.microsoft.com/api/products?view=enterprise",
             "Platforms": [
                 "Windows",
                 "Any"

--- a/Evergreen/Manifests/MicrosoftEdgeWebView2Runtime.json
+++ b/Evergreen/Manifests/MicrosoftEdgeWebView2Runtime.json
@@ -23,7 +23,7 @@
         },
         "Download": {
             "Uri": {
-                "ARM64": "https://go.microsoft.com/fwlink/?linkid=2099616",
+                "arm64": "https://go.microsoft.com/fwlink/?linkid=2099616",
                 "x64": "https://go.microsoft.com/fwlink/?linkid=2124701",
                 "x86": "https://go.microsoft.com/fwlink/?linkid=2099617"
             }


### PR DESCRIPTION
* Fixes `MicrosoftEdge`, `MicrosoftEdgeWebView2Runtime` for missing `Stable` channel #826
* Adds `MicrosoftEdgeForBusiness`

BREAKING CHANGE

* `MicrosoftEdge` is split into `MicrosoftEdge` and `MicrosoftEdgeForBusiness`
* `MicrosoftEdge` shows current versions only for each architecture - previous `Consumer` and `Enterprise` releases were showing the same version anyway
* `Release` property only includes `Enterprise` to avoid breaking existing scripts
* `MicrosoftEdgeForBusiness` shows all data available for Edge, including Administrative Templates
