### PR TITLE
Apps

### DIFF
--- a/Evergreen/Manifests/MicrosoftEdgeDriver.json
+++ b/Evergreen/Manifests/MicrosoftEdgeDriver.json
@@ -15,7 +15,7 @@
             "Architectures": [
                 "x64",
                 "x86",
-                "ARM64"
+                "arm64"
             ],
             "ReleaseProperty": "Releases",
             "SortProperty": "ProductVersion",
@@ -25,7 +25,7 @@
         },
         "Download": {
             "Uri": {
-                "ARM64": "https://msedgedriver.azureedge.net/#version/edgedriver_arm64.zip",
+                "arm64": "https://msedgedriver.azureedge.net/#version/edgedriver_arm64.zip",
                 "x64": "https://msedgedriver.azureedge.net/#version/edgedriver_win64.zip",
                 "x86": "https://msedgedriver.azureedge.net/#version/edgedriver_win32.zip"
             }

--- a/Evergreen/Shared/Get-SourceForgeRepoRelease.ps1
+++ b/Evergreen/Shared/Get-SourceForgeRepoRelease.ps1
@@ -102,7 +102,8 @@
             Type         = [System.IO.Path]::GetExtension($Url).Split(".")[-1]
             Size         = $item.content.filesize
             Md5          = $item.content.hash.'#text'
-            URI          = $Url
+            FileName     = Split-Path -Path $Url -Leaf
+            URI          = "$($Url)?viasf=1"
         }
         Write-Output -InputObject $PSObject
     }

--- a/tests/Shared/Get-SourceForgeRepoRelease.Tests.ps1
+++ b/tests/Shared/Get-SourceForgeRepoRelease.Tests.ps1
@@ -34,6 +34,9 @@ Describe -Name "Get-SourceForgeRepoRelease" {
                 $object.Version.Length | Should -BeGreaterThan 0
                 $object.Architecture.Length | Should -BeGreaterThan 0
                 $object.Type.Length | Should -BeGreaterThan 0
+                $object.Size.Length | Should -BeGreaterThan 0
+                $object.Md5.Length | Should -BeGreaterThan 0
+                $object.FileName.Length | Should -BeGreaterThan 0
                 $object.URI.Length | Should -BeGreaterThan 0
             }
         }


### PR DESCRIPTION
* Updates `MicrosoftEdgeDriver` for missing Stable channel
* Updates `Get-SourceForgeRepoRelease` to add `?viasf=1` to returns URLs which enables `Save-EvergreenApp` to download files without a custom user agent