### PR TITLE
Update Azure Pipelines Agent download URLs

### DIFF
--- a/Evergreen/Manifests/MicrosoftAzurePipelinesAgent.json
+++ b/Evergreen/Manifests/MicrosoftAzurePipelinesAgent.json
@@ -9,8 +9,8 @@
 		},
 		"Download": {
 			"Uri": {
-				"x64": "https://vstsagentpackage.azureedge.net/agent/#version/vsts-agent-win-x64-#version.zip",
-				"x86": "https://vstsagentpackage.azureedge.net/agent/#version/vsts-agent-win-x86-#version.zip"
+				"x64": "https://download.agent.dev.azure.com/agent/#version/vsts-agent-win-x64-#version.zip",
+				"x86": "https://download.agent.dev.azure.com/agent/#version/vsts-agent-win-x86-#version.zip"
 			},
 			"ReplaceText": "#version"
 		}

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,9 @@
 # Change log
 
+## VERSION
+
+* Fixes change to download URL in `MicrosoftAzurePipelinesAgent`
+
 ## 2506.2209
 
 * Modifies the URI to include '?viasf=1' in `Get-SourceForgeRepoRelease` for all SourceForge hosted apps to ensure downloads with `Save-EvergreenApp` works


### PR DESCRIPTION
Changed the download URLs in MicrosoftAzurePipelinesAgent.json to use download.agent.dev.azure.com instead of vstsagentpackage.azureedge.net. Updated changelog to reflect this fix.