### PR TITLE
Creates a custom Evergreen user agent

### DIFF
--- a/Evergreen/Evergreen.psm1
+++ b/Evergreen/Evergreen.psm1
@@ -26,6 +26,7 @@ foreach ($Import in @($Public + $Private + $Shared)) {
 
 # Get module strings
 $script:resourceStrings = Get-ModuleResource
+$script:UserAgent = Get-EvergreenUserAgent
 
 # Register the argument completer for the Get-EvergreenApp and Find-EvergreenApp cmdlets
 $Commands = "Get-EvergreenApp", "Find-EvergreenApp", "Get-EvergreenAppFromApi", "Export-EvergreenManifest", "Get-EvergreenLibraryApp", "Get-EvergreenEndpointFromApi"

--- a/Evergreen/Private/Get-EvergreenUserAgent.ps1
+++ b/Evergreen/Private/Get-EvergreenUserAgent.ps1
@@ -1,0 +1,3 @@
+function Get-EvergreenUserAgent {
+    return "Evergreen/$(Get-ModuleVersion)"
+}

--- a/Evergreen/Private/Get-EvergreenUserAgent.ps1
+++ b/Evergreen/Private/Get-EvergreenUserAgent.ps1
@@ -1,3 +1,3 @@
 function Get-EvergreenUserAgent {
-    return "Evergreen/$(Get-ModuleVersion)"
+    return "Evergreen/$(Get-ModuleVersion) (https://github.com/aaronparker/evergreen; PowerShell $($PSVersionTable.PSVersion); $(Get-OSName))"
 }

--- a/Evergreen/Private/Get-ModuleVersion.ps1
+++ b/Evergreen/Private/Get-ModuleVersion.ps1
@@ -1,0 +1,15 @@
+function Get-ModuleVersion {
+    try {
+        $ErrorActionPreference = "Stop"
+        $module = (Get-Module -Name $MyInvocation.MyCommand.ModuleName -All)[0]
+        if ($null -ne $module) {
+            return $module.Version
+        }
+        else {
+            return $(Get-Date -Format "yyMM.2525")
+        }
+    }
+    catch {
+        return $(Get-Date -Format "yyMM.2525")
+    }
+}

--- a/Evergreen/Private/Get-ModuleVersion.ps1
+++ b/Evergreen/Private/Get-ModuleVersion.ps1
@@ -6,10 +6,10 @@ function Get-ModuleVersion {
             return $module.Version
         }
         else {
-            return $(Get-Date -Format "yyMM.2525")
+            return $(Get-Date -Format "yyMM.9999")
         }
     }
     catch {
-        return $(Get-Date -Format "yyMM.2525")
+        return $(Get-Date -Format "yyMM.9999")
     }
 }

--- a/Evergreen/Private/Get-OSName.ps1
+++ b/Evergreen/Private/Get-OSName.ps1
@@ -1,0 +1,24 @@
+function Get-OSName {
+    # OS name based on version
+    if ($IsCoreCLR) {
+        $os = if ($IsWindows) {
+            (Get-CimInstance Win32_OperatingSystem).Caption
+        }
+        elseif ($IsLinux) {
+            (uname)  # Assuming you're in a shell context or using Invoke-Expression
+        }
+        elseif ($IsMacOS) {
+            "macOS"  # Or use `sw_vers` for more granularity
+        }
+    }
+    else {
+        # PowerShell 5.1 fallback via WMI
+        try {
+            $os = (Get-CimInstance Win32_OperatingSystem).Caption
+        }
+        catch {
+            $os = "Unknown Windows"
+        }
+    }
+    return $os
+}

--- a/Evergreen/Private/Invoke-EvergreenRestMethod.ps1
+++ b/Evergreen/Private/Invoke-EvergreenRestMethod.ps1
@@ -36,7 +36,7 @@ function Invoke-EvergreenRestMethod {
 
         [Parameter()]
         [ValidateNotNullOrEmpty()]
-        [System.String] $UserAgent = $script:resourceStrings.UserAgent.Base,
+        [System.String] $UserAgent = $script:UserAgent,
 
         [Parameter()]
         [System.Management.Automation.SwitchParameter] $SkipCertificateCheck,

--- a/Evergreen/Private/Invoke-EvergreenWebRequest.ps1
+++ b/Evergreen/Private/Invoke-EvergreenWebRequest.ps1
@@ -30,7 +30,7 @@ function Invoke-EvergreenWebRequest {
 
         [Parameter()]
         [ValidateNotNullOrEmpty()]
-        [System.String] $UserAgent = $script:resourceStrings.UserAgent.Base,
+        [System.String] $UserAgent = $script:UserAgent,
 
         [Parameter()]
         [System.Management.Automation.SwitchParameter] $Raw,

--- a/Evergreen/Private/Invoke-SystemNetRequest.ps1
+++ b/Evergreen/Private/Invoke-SystemNetRequest.ps1
@@ -12,7 +12,7 @@ Function Invoke-SystemNetRequest {
 
         [Parameter(Position = 1)]
         [ValidateNotNullOrEmpty()]
-        [System.String] $UserAgent = $script:resourceStrings.UserAgent.Base,
+        [System.String] $UserAgent = $script:UserAgent,
 
         [Parameter()]
         [ValidateNotNullOrEmpty()]

--- a/Evergreen/Private/Resolve-InvokeWebRequest.ps1
+++ b/Evergreen/Private/Resolve-InvokeWebRequest.ps1
@@ -12,7 +12,7 @@ function Resolve-InvokeWebRequest {
         [System.String] $Uri,
 
         [Parameter(Position = 1)]
-        [System.String] $UserAgent = $script:resourceStrings.UserAgent.Base,
+        [System.String] $UserAgent = $script:UserAgent,
 
         [Parameter(Position = 2)]
         [ValidateNotNullOrEmpty()]

--- a/Evergreen/Private/Resolve-SystemNetWebRequest.ps1
+++ b/Evergreen/Private/Resolve-SystemNetWebRequest.ps1
@@ -12,7 +12,7 @@ function Resolve-SystemNetWebRequest {
         [System.String] $Uri,
 
         [Parameter(Position = 1)]
-        [System.String] $UserAgent = $script:resourceStrings.UserAgent.Base,
+        [System.String] $UserAgent = $script:UserAgent,
 
         [Parameter()]
         [ValidateNotNullOrEmpty()]

--- a/Evergreen/Private/Save-File.ps1
+++ b/Evergreen/Private/Save-File.ps1
@@ -20,7 +20,7 @@
             Uri             = $Uri
             OutFile         = $OutFile
             UseBasicParsing = $True
-            UserAgent       = $script:resourceStrings.UserAgent.Base
+            UserAgent       = $script:UserAgent
         }
         if (Test-PSCore) {
             $params.SslProtocol = "Tls12"

--- a/Evergreen/Public/Get-EvergreenAppFromApi.ps1
+++ b/Evergreen/Public/Get-EvergreenAppFromApi.ps1
@@ -21,7 +21,7 @@ function Get-EvergreenAppFromApi {
         try {
             $params = @{
                 Uri         = "https://evergreen-api.stealthpuppy.com/app/$Name"
-                UserAgent   = "Evergreen/$((Get-Module -Name "Evergreen").Version)"
+                UserAgent   = (Get-EvergreenUserAgent)
                 ErrorAction = "Stop"
             }
             Invoke-EvergreenRestMethod @params

--- a/Evergreen/Public/Save-EvergreenApp.ps1
+++ b/Evergreen/Public/Save-EvergreenApp.ps1
@@ -40,7 +40,7 @@ function Save-EvergreenApp {
 
         [Parameter()]
         [ValidateNotNullOrEmpty()]
-        [System.String] $UserAgent = $script:resourceStrings.UserAgent.Base,
+        [System.String] $UserAgent = $script:UserAgent,
 
         [Parameter(Mandatory = $false)]
         [System.Management.Automation.SwitchParameter] $Force,
@@ -140,17 +140,17 @@ function Save-EvergreenApp {
             if ($PSBoundParameters.ContainsKey("Force") -or !(Test-Path -Path $DownloadFile -PathType "Leaf")) {
                 #region Download the file
                 # If URL in the catch list, customise the user agent
-                if ($Object.URI -match $script:resourceStrings.UserAgent.CatchList -and -not($PSBoundParameters.ContainsKey("UserAgent"))) {
-                    Write-Verbose -Message "URL matches catch list for custom user agent: $($Object.URI)."
-                    $UserAgent = "Evergreen/$((Get-Module -Name "Evergreen").Version)"
-                }
+                # if ($Object.URI -match $script:resourceStrings.UserAgent.CatchList -and -not($PSBoundParameters.ContainsKey("UserAgent"))) {
+                #     Write-Verbose -Message "URL matches catch list for custom user agent: $($Object.URI)."
+                #     $UserAgent = $script:UserAgent
+                # }
 
                 # Invoke-WebRequest parameters
                 $params = @{
                     Uri             = $Object.URI
                     OutFile         = $DownloadFile
                     UseBasicParsing = $true
-                    UserAgent       = $UserAgent
+                    UserAgent       = $script:UserAgent
                     ErrorAction     = "Continue"
                 }
                 if ($PSBoundParameters.ContainsKey("Proxy")) {

--- a/Evergreen/Public/Test-EvergreenApp.ps1
+++ b/Evergreen/Public/Test-EvergreenApp.ps1
@@ -23,7 +23,7 @@ function Test-EvergreenApp {
 
         [Parameter()]
         [ValidateNotNullOrEmpty()]
-        [System.String] $UserAgent = $script:resourceStrings.UserAgent.Base,
+        [System.String] $UserAgent = $script:UserAgent,
 
         [Parameter(Mandatory = $false)]
         [System.Management.Automation.SwitchParameter] $Force,

--- a/Evergreen/Shared/Get-SourceForgeRepoRelease.ps1
+++ b/Evergreen/Shared/Get-SourceForgeRepoRelease.ps1
@@ -23,7 +23,7 @@
     # Retrieve best release json
     $params = @{
         Uri       = $Uri
-        UserAgent = "Evergreen/$((Get-Module -Name "Evergreen").Version)"
+        UserAgent = (Get-EvergreenUserAgent)
     }
     $BestRelease = Invoke-EvergreenRestMethod @params
 
@@ -63,7 +63,7 @@
     # Find the mirror for the download
     $params = @{
         Uri       = $BestRelease.platform_releases.windows.url
-        UserAgent = $null
+        UserAgent = (Get-EvergreenUserAgent)
     }
     $Resolved = Resolve-SystemNetWebRequest @params
     Write-Verbose -Message "$($MyInvocation.MyCommand): Resolve mirror to: $($Resolved.ResponseUri.Host)."
@@ -72,6 +72,7 @@
     $params = @{
         Uri         = "$($Download.Feed)$Folder"
         ContentType = $Download.ContentType
+        UserAgent   = (Get-EvergreenUserAgent)
     }
     $Content = Invoke-EvergreenRestMethod @params
 


### PR DESCRIPTION
Creates a custom Evergreen user agent in this format:

`Evergreen/<version> (https://github.com/aaronparker/evergreen; PowerShell <PowerShell version>; <OS platform)`

Example: `Evergreen/2508.9999 (https://github.com/aaronparker/evergreen; PowerShell 7.5.2; macOS)`

This approach should achieve the following:
* Ensures Evergreen can be identified on calls to target endpoints
* Avoids the need to update the previous user agent (The default Microsoft Edge on Windows user agent was being used) - some vendor endpoints will block out of date user agents

This change introduces the following private functions:
* Get-EvergreenUserAgent
* Get-ModuleVersion
* Get-OSName

The following functions are updated to use the Evergreen user agent
* Invoke-EvergreenRestMethod
* Invoke-EvergreenWebRequest
* Invoke-SystemNetRequest
* Save-File
* Get-EvergreenAppFromApi
* Save-EvergreenApp
* Test-EvergreenApp
* Get-SourceForgeRepoRelease