### PR TITLE
Fixing filename for OBS Studio installer

### DIFF
--- a/Evergreen/Manifests/OBSStudio.json
+++ b/Evergreen/Manifests/OBSStudio.json
@@ -13,7 +13,7 @@
         },
         "Download": {
             "Uri": "https://cdn-fastly.obsproject.com/downloads/#FileName",
-            "FileName": "OBS-Studio-#Version-Windows-Installer.exe",
+            "FileName": "OBS-Studio-#Version-Windows-x64-Installer.exe",
             "Architectures": [
                 "x64"
             ],


### PR DESCRIPTION
The installer name has been changed from OBS-Studio-31.1.2-Windows-Installer.exe to OBS-Studio-31.1.2-Windows-x64-Installer.exe