### PR TITLE
Add ImageType property to Amazon Corretto output

### DIFF
--- a/Evergreen/Shared/Get-AmazonCorretto.ps1
+++ b/Evergreen/Shared/Get-AmazonCorretto.ps1
@@ -23,10 +23,22 @@ function Get-AmazonCorretto {
 
         # Construct the output; Return the custom object to the pipeline
         if ($null -ne $Response) {
+
+            $ImageType = if ($Url -match "jre") {
+                "JRE"
+            }
+            elseif ($Url -match "jdk") {
+                "JDK"
+            }
+            else {
+                "Unknown"
+            }
+
             $PSObject = [PSCustomObject] @{
                 Version      = [RegEx]::Match($Response.ResponseUri.LocalPath, $res.Get.Download.MatchVersion).Captures.Groups[1].Value
                 Md5          = (Invoke-EvergreenWebRequest -Uri $ChecksumUrl -Raw -ReturnObject "Content")
                 Architecture = Get-Architecture -String $Response.ResponseUri.AbsoluteUri
+                ImageType    = $ImageType
                 Type         = Get-FileType -File $Response.ResponseUri.AbsoluteUri
                 URI          = $Response.ResponseUri.AbsoluteUri
             }


### PR DESCRIPTION
Introduces an `ImageType` field to the returned object in `Get-AmazonCorretto.ps1`, distinguishing between `JRE`, `JDK`, or Unknown based on the download URL.